### PR TITLE
Resolve plugin paths relative to the config file loading them

### DIFF
--- a/crates/config/src/errors.rs
+++ b/crates/config/src/errors.rs
@@ -9,6 +9,8 @@ pub enum ConfigFileError {
     Validation(#[from] validator::ValidationError),
     #[error(transparent)]
     Validations(#[from] validator::ValidationErrors),
+    #[error("missing parent: '{0}'")]
+    MissingParent(String),
 }
 
 /// This error will be returned if an attempt to serialize a config structure fails.

--- a/crates/config/src/toml.rs
+++ b/crates/config/src/toml.rs
@@ -522,4 +522,14 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_resolve_path() -> Result<(), Box<dyn std::error::Error>> {
+        let base = PathBuf::new().join(".");
+        let path = Path::new("./src");
+        let resolved_path = resolve_path(&base, path)?;
+
+        assert!(resolved_path.ends_with("crates/config/src"));
+        Ok(())
+    }
 }

--- a/crates/config/src/toml.rs
+++ b/crates/config/src/toml.rs
@@ -456,7 +456,12 @@ mod tests {
 
         assert_eq!(root.plugins.len(), 1);
         assert_eq!(root.plugins.get(0).unwrap().reference, "evil_bit");
-        assert_eq!(root.plugins.get(0).unwrap().path, "bulwark-evil-bit.wasm");
+        assert!(root
+            .plugins
+            .get(0)
+            .unwrap()
+            .path
+            .ends_with("bulwark-evil-bit.wasm"));
         assert_eq!(
             root.plugins.get(0).unwrap().config,
             toml::map::Map::default()
@@ -490,7 +495,12 @@ mod tests {
 
         assert_eq!(root.plugins.len(), 2);
         assert_eq!(root.plugins.get(0).unwrap().reference, "evil_bit");
-        assert_eq!(root.plugins.get(0).unwrap().path, "bulwark-evil-bit.wasm");
+        assert!(root
+            .plugins
+            .get(0)
+            .unwrap()
+            .path
+            .ends_with("bulwark-evil-bit.wasm"));
         assert_eq!(
             root.plugins.get(0).unwrap().config,
             serde_json::map::Map::default()


### PR DESCRIPTION
Previously, plugins were loaded relative to the current directory. This could be a source of confusing and inconsistent behavior if config includes were in different directories from the main config or if the main config was loaded from anywhere other than the current working directory.

This fixes that by resolving plugin paths relative to the config file loading them and canonicalizing to absolute paths.