### PR TITLE
Add GitHub Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+## Contact
+Security bugs may be privately reported to security@bulwark.security.
+
+## Scope
+Due to Bulwark's design as a security engine that hosts detections as separate, customizable, composable units, security reports should not be sent for individual detections or specific combinations of detections. Instead, please refer to the [Testing](https://docs.bulwark.security/contributing/testing) section for details on how best to report these.
+Reports related to the security of the engine itself are welcomed at the contact address above. Since the tool is currently in a public beta testing phase, there is currently no active formal bug bounty program.


### PR DESCRIPTION
## Proposed Change
This does nothing but structure the existing information from the [Security Reports](https://docs.bulwark.security/contributing/security-reports) section of Bulwark's documentation in GitHub.

## Benefit
Adding the security policy as a `SECURITY.md` at the root of the repository will make it indexible by GitHub - enabling the **Security Policy** option under the **Security** tab, and any expanded functionality GitHub introduces based on it. Similar to how GitHub prompted me to check out `CODE_OF_CONDUCT.md` before creating this as a first time contributor.

This metadata is also picked up by sources like Snyk Advisor.
![image](https://github.com/bulwark-security/bulwark/assets/34169713/ddc7b037-7095-4b82-ad25-8b0183795e88)