### PR TITLE
Implement Default for Decision

### DIFF
--- a/crates/decision/src/decision.rs
+++ b/crates/decision/src/decision.rs
@@ -38,6 +38,18 @@ pub struct Decision {
     pub unknown: f64,
 }
 
+impl Default for Decision {
+    /// The default [`Decision`] assigns nothing to the `accept` and `restrict` components and everything
+    /// to the `unknown` component.
+    fn default() -> Self {
+        Self {
+            accept: 0.0,
+            restrict: 0.0,
+            unknown: 1.0,
+        }
+    }
+}
+
 /// A decision representing acceptance with full certainty.
 pub const ACCEPT: Decision = Decision {
     accept: 1.0,

--- a/crates/decision/src/decision.rs
+++ b/crates/decision/src/decision.rs
@@ -42,11 +42,7 @@ impl Default for Decision {
     /// The default [`Decision`] assigns nothing to the `accept` and `restrict` components and everything
     /// to the `unknown` component.
     fn default() -> Self {
-        Self {
-            accept: 0.0,
-            restrict: 0.0,
-            unknown: 1.0,
-        }
+        UNKNOWN
     }
 }
 


### PR DESCRIPTION
The default `Decision` assigns nothing to the `accept` and `restrict` components and everything to the `unknown` component.