### PR TITLE
Tidy up GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Rust
 
 on:
   push:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - master
     paths:
     - .github/workflows/semgrep.yml
   schedule:


### PR DESCRIPTION
Rename the Rust actions to reflect that they're not the entirety of CI and remove unused branch names.