### PR TITLE
Result type return values for API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "thiserror",
  "tokio-test",
  "url",
+ "validator",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",

--- a/crates/wasm-host/Cargo.toml
+++ b/crates/wasm-host/Cargo.toml
@@ -37,6 +37,7 @@ reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
 url = "2.3.1"
 futures = "0.3"
 async-trait = "0.1.68"
+validator = { version = "0.16" }
 
 [dev-dependencies]
 wasi-cap-std-sync = { version = "10" }

--- a/crates/wasm-host/src/errors.rs
+++ b/crates/wasm-host/src/errors.rs
@@ -33,7 +33,7 @@ pub enum PluginExecutionError {
     WasiError(#[from] wasi_common::Error),
     #[error(transparent)]
     StringArray(#[from] wasi_common::StringArrayError),
-    #[error("function not implemented '{expected:?}'")]
+    #[error("function not implemented '{expected}'")]
     NotImplementedError { expected: String },
     #[error(transparent)]
     AnyError(#[from] anyhow::Error),

--- a/crates/wasm-host/src/plugin.rs
+++ b/crates/wasm-host/src/plugin.rs
@@ -901,31 +901,30 @@ impl bulwark_host::HostApiImports for RequestContext {
     /// Typically used in the feedback phase.
     async fn get_combined_decision(
         &mut self,
-    ) -> Result<bulwark_host::DecisionInterface, wasmtime::Error> {
+    ) -> Result<Option<bulwark_host::DecisionInterface>, wasmtime::Error> {
         let combined_decision: MutexGuard<Option<bulwark_host::DecisionInterface>> =
             self.host_mutable_context.combined_decision.lock().unwrap();
-        // TODO: this should probably be an Option return type rather than unwrapping here
-        Ok(combined_decision.to_owned().unwrap())
+        Ok(combined_decision.to_owned())
     }
 
     /// Returns the combined set of tags associated with a decision, if available.
     ///
     /// Typically used in the feedback phase.
-    async fn get_combined_tags(&mut self) -> Result<Vec<String>, wasmtime::Error> {
+    async fn get_combined_tags(&mut self) -> Result<Option<Vec<String>>, wasmtime::Error> {
         let combined_tags: MutexGuard<Option<Vec<String>>> =
             self.host_mutable_context.combined_tags.lock().unwrap();
-        // TODO: this should probably be an Option return type rather than unwrapping here
-        Ok(combined_tags.to_owned().unwrap())
+        Ok(combined_tags.to_owned())
     }
 
     /// Returns the outcome of the combined decision, if available.
     ///
     /// Typically used in the feedback phase.
-    async fn get_outcome(&mut self) -> Result<bulwark_host::OutcomeInterface, wasmtime::Error> {
+    async fn get_outcome(
+        &mut self,
+    ) -> Result<Option<bulwark_host::OutcomeInterface>, wasmtime::Error> {
         let outcome: MutexGuard<Option<bulwark_host::OutcomeInterface>> =
             self.host_mutable_context.outcome.lock().unwrap();
-        // TODO: this should probably be an Option return type rather than unwrapping here
-        Ok(outcome.to_owned().unwrap())
+        Ok(outcome.to_owned())
     }
 
     /// Returns the named state value retrieved from Redis.
@@ -1299,14 +1298,11 @@ impl bulwark_host::HostApiImports for RequestContext {
 
 /// Ensures that access to any remote state key has the appropriate permissions set.
 fn verify_remote_state_prefixes(
-    allowed_key_prefixes: &Vec<String>,
+    // TODO: BTreeSet<String> instead, all the way up
+    allowed_key_prefixes: &[String],
     key: &str,
 ) -> Result<(), bulwark_host::StateError> {
     let key = key.to_string();
-    let allowed_key_prefixes = allowed_key_prefixes
-        .iter()
-        .cloned()
-        .collect::<BTreeSet<String>>();
     if !allowed_key_prefixes
         .iter()
         .any(|prefix| key.starts_with(prefix))

--- a/crates/wasm-host/src/plugin.rs
+++ b/crates/wasm-host/src/plugin.rs
@@ -734,11 +734,15 @@ impl bulwark_host::HostApiImports for RequestContext {
     }
 
     /// Returns the response received from the interior service.
-    async fn get_response(&mut self) -> Result<bulwark_host::ResponseInterface, wasmtime::Error> {
+    ///
+    /// If called from `on_request` or `on_request_decision`, it will return `None` since a response
+    /// is not yet available.
+    async fn get_response(
+        &mut self,
+    ) -> Result<Option<bulwark_host::ResponseInterface>, wasmtime::Error> {
         let response: MutexGuard<Option<bulwark_host::ResponseInterface>> =
             self.host_mutable_context.response.lock().unwrap();
-        // TODO: remove unwrap
-        Ok(response.to_owned().unwrap())
+        Ok(response.to_owned())
     }
 
     /// Returns the originating client's IP address, if available.

--- a/crates/wasm-host/src/plugin.rs
+++ b/crates/wasm-host/src/plugin.rs
@@ -800,7 +800,7 @@ impl bulwark_host::HostApiImports for RequestContext {
                 // remove/insert to avoid move issues
                 let mut builder = outbound_requests
                     .remove(&request_id)
-                    .ok_or_else(|| bulwark_host::HttpError::MissingId(request_id))?;
+                    .ok_or(bulwark_host::HttpError::MissingId(request_id))?;
                 builder = builder.header(name, value);
                 outbound_requests.insert(request_id, builder);
                 Ok(())
@@ -830,7 +830,7 @@ impl bulwark_host::HostApiImports for RequestContext {
                 let mut outbound_requests = self.outbound_http.lock().unwrap();
                 let builder = outbound_requests
                     .remove(&request_id)
-                    .ok_or_else(|| bulwark_host::HttpError::MissingId(request_id))?;
+                    .ok_or(bulwark_host::HttpError::MissingId(request_id))?;
                 let builder = builder.body(body);
 
                 let response = builder

--- a/crates/wasm-sdk/Cargo.toml
+++ b/crates/wasm-sdk/Cargo.toml
@@ -19,7 +19,7 @@ bulwark-wasm-sdk-macros = { path = "../wasm-sdk-macros", version = "0.1.0" }
 thiserror = "1.0.37"
 anyhow = "1"
 http = "0.2"
-validator = { version = "0.16", features = ["derive"] }
+validator = { version = "0.16" }
 approx = "0.5"
 wit-bindgen = "0.7.0"
 serde_json = "1.0.93"

--- a/crates/wasm-sdk/src/errors.rs
+++ b/crates/wasm-sdk/src/errors.rs
@@ -4,17 +4,43 @@ pub type Result = ::std::result::Result<(), Error>;
 /// Generic error
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// Returned when an attempt to parse a counter within a plugin environment fails.
     #[error(transparent)]
     ParseCounter(#[from] ParseCounterError),
-    /// Triggered when there can only be a single validation error
+    /// Returned when an attempt to convert to a [`String`] fails due to invalid utf8 byte sequences.
+    #[error(transparent)]
+    FromUtf8(#[from] std::string::FromUtf8Error),
+    /// Returned when an attempt to access a resource that requires a permission fails.
+    #[error(transparent)]
+    Permission(#[from] PermissionError),
+    /// Returned when there is an issue with the environment variable requested by the plugin.
+    #[error(transparent)]
+    EnvVar(#[from] EnvVarError),
+    /// Returned when there can only be a single validation error
     #[error(transparent)]
     Validation(#[from] validator::ValidationError),
-    /// Triggered when there could be multiple validation errors
+    /// Returned when there could be multiple validation errors
     #[error(transparent)]
     Validations(#[from] validator::ValidationErrors),
     /// Catch-all error type
     #[error(transparent)]
-    AnyError(#[from] anyhow::Error),
+    Any(#[from] anyhow::Error),
+}
+
+impl From<crate::bulwark_host::EnvError> for Error {
+    fn from(error: crate::bulwark_host::EnvError) -> Self {
+        match error {
+            crate::bulwark_host::EnvError::Permission(var) => {
+                Error::Permission(PermissionError::Environment { var })
+            }
+            crate::bulwark_host::EnvError::Missing(var) => {
+                Error::EnvVar(EnvVarError::Missing { var })
+            }
+            crate::bulwark_host::EnvError::NotUnicode(var) => {
+                Error::EnvVar(EnvVarError::NotUnicode { var })
+            }
+        }
+    }
 }
 
 /// Returned when an attempt to parse a counter within a plugin environment fails.
@@ -24,4 +50,24 @@ pub enum ParseCounterError {
     ParseInt(#[from] std::num::ParseIntError),
     #[error(transparent)]
     Utf8(#[from] std::str::Utf8Error),
+}
+
+/// Returned when an attempt to access a resource that requires a permission fails.
+#[derive(thiserror::Error, Debug)]
+pub enum PermissionError {
+    #[error("access to environment variable '{var}' denied")]
+    Environment { var: String },
+    #[error("access to http host '{host}' denied")]
+    Http { host: String },
+    #[error("access to state key '{key}' denied")]
+    State { key: String },
+}
+
+/// Returned when there is an issue with the environment variable requested by the plugin.
+#[derive(thiserror::Error, Debug)]
+pub enum EnvVarError {
+    #[error("environment variable '{var}' missing")]
+    Missing { var: String },
+    #[error("environment variable '{var}' was not unicode")]
+    NotUnicode { var: String },
 }

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -78,8 +78,8 @@ pub const NO_BODY: BodyChunk = BodyChunk {
 pub fn get_request() -> Request {
     let raw_request: crate::bulwark_host::RequestInterface = crate::bulwark_host::get_request();
     let chunk: Vec<u8> = raw_request.chunk;
-    // TODO: error handling
-    let method = Method::from_str(raw_request.method.as_str()).unwrap();
+    // This code shouldn't be reachable if the method is invalid
+    let method = Method::from_str(raw_request.method.as_str()).expect("should be a valid method");
     let mut request = http::Request::builder()
         .method(method)
         .uri(raw_request.uri)
@@ -94,7 +94,8 @@ pub fn get_request() -> Request {
             start: raw_request.chunk_start,
             end_of_stream: raw_request.end_of_stream,
         })
-        .unwrap()
+        // Everything going into the builder should have already been validated somewhere else
+        .expect("should be a valid request")
 }
 
 /// Returns the response received from the interior service.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -93,6 +93,7 @@ pub fn get_request() -> Request {
             end_of_stream: raw_request.end_of_stream,
         })
         // Everything going into the builder should have already been validated somewhere else
+        // Proxy layer shouldn't send it through if it's invalid
         .expect("should be a valid request")
 }
 
@@ -114,6 +115,7 @@ pub fn get_response() -> Option<Response> {
                 end_of_stream: raw_response.end_of_stream,
             })
             // Everything going into the builder should have already been validated somewhere else
+            // Proxy layer shouldn't send it through if it's invalid
             .expect("should be a valid response"),
     )
 }

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -127,11 +127,11 @@ pub fn get_client_ip() -> Option<IpAddr> {
 /// # Arguments
 ///
 /// * `key` - The key name corresponding to the param value.
-pub fn get_param_value(key: &str) -> Value {
+pub fn get_param_value(key: &str) -> Result<Value, crate::Error> {
     // TODO: this should return a result
-    let raw_value = crate::bulwark_host::get_param_value(key);
+    let raw_value = crate::bulwark_host::get_param_value(key)?;
     let value: serde_json::Value = serde_json::from_slice(&raw_value).unwrap();
-    value
+    Ok(value)
 }
 
 /// Set a named value in the request context's params.
@@ -140,10 +140,11 @@ pub fn get_param_value(key: &str) -> Value {
 ///
 /// * `key` - The key name corresponding to the param value.
 /// * `value` - The value to record. Values are serialized JSON.
-pub fn set_param_value(key: &str, value: Value) {
+pub fn set_param_value(key: &str, value: Value) -> Result<(), crate::Error> {
     // TODO: this should return a result
-    let json = serde_json::to_vec(&value).unwrap();
-    crate::bulwark_host::set_param_value(key, &json);
+    let json = serde_json::to_vec(&value)?;
+    crate::bulwark_host::set_param_value(key, &json)?;
+    Ok(())
 }
 
 /// Returns the guest environment's configuration value as a JSON [`Value`].

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -407,8 +407,8 @@ pub fn set_remote_state(key: &str, value: &[u8]) -> Result<(), crate::Error> {
 ///
 /// * `key` - The key name corresponding to the state counter.
 #[inline]
-pub fn increment_remote_state(key: &str) -> i64 {
-    crate::bulwark_host::increment_remote_state(key)
+pub fn increment_remote_state(key: &str) -> Result<i64, crate::Error> {
+    Ok(crate::bulwark_host::increment_remote_state(key)?)
 }
 
 /// Increments a named counter in Redis by a specified delta value.
@@ -423,8 +423,8 @@ pub fn increment_remote_state(key: &str) -> i64 {
 /// * `key` - The key name corresponding to the state counter.
 /// * `delta` - The amount to increase the counter by.
 #[inline]
-pub fn increment_remote_state_by(key: &str, delta: i64) -> i64 {
-    crate::bulwark_host::increment_remote_state_by(key, delta)
+pub fn increment_remote_state_by(key: &str, delta: i64) -> Result<i64, crate::Error> {
+    Ok(crate::bulwark_host::increment_remote_state_by(key, delta)?)
 }
 
 /// Sets an expiration on a named value in Redis.
@@ -437,8 +437,8 @@ pub fn increment_remote_state_by(key: &str, delta: i64) -> i64 {
 /// * `key` - The key name corresponding to the state value.
 /// * `ttl` - The time-to-live for the value in seconds.
 #[inline]
-pub fn set_remote_ttl(key: &str, ttl: i64) {
-    crate::bulwark_host::set_remote_ttl(key, ttl)
+pub fn set_remote_ttl(key: &str, ttl: i64) -> Result<(), crate::Error> {
+    Ok(crate::bulwark_host::set_remote_ttl(key, ttl)?)
 }
 
 // TODO: needs an example

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -368,8 +368,8 @@ pub fn send_request(request: Request) -> Response {
 ///
 /// * `key` - The key name corresponding to the state value.
 #[inline]
-pub fn get_remote_state(key: &str) -> Vec<u8> {
-    crate::bulwark_host::get_remote_state(key)
+pub fn get_remote_state(key: &str) -> Result<Vec<u8>, crate::Error> {
+    Ok(crate::bulwark_host::get_remote_state(key)?)
 }
 
 /// Parses a counter value from state stored as a string.
@@ -392,8 +392,8 @@ pub fn parse_counter(value: Vec<u8>) -> Result<i64, ParseCounterError> {
 /// * `key` - The key name corresponding to the state value.
 /// * `value` - The value to record. Values are byte strings, but may be interpreted differently by Redis depending on context.
 #[inline]
-pub fn set_remote_state(key: &str, value: &[u8]) {
-    crate::bulwark_host::set_remote_state(key, value)
+pub fn set_remote_state(key: &str, value: &[u8]) -> Result<(), crate::Error> {
+    Ok(crate::bulwark_host::set_remote_state(key, value)?)
 }
 
 /// Increments a named counter in Redis.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -338,13 +338,13 @@ pub fn get_outcome() -> Option<Outcome> {
 /// # Arguments
 ///
 /// * `request` - The HTTP request to send.
-pub fn send_request(request: Request) -> Response {
+pub fn send_request(request: Request) -> Result<Response, crate::Error> {
     let request_id = crate::bulwark_host::prepare_request(
         request.method().as_str(),
         request.uri().to_string().as_str(),
-    );
+    )?;
     for (name, value) in request.headers() {
-        crate::bulwark_host::add_request_header(request_id, name.as_str(), value.as_bytes());
+        crate::bulwark_host::add_request_header(request_id, name.as_str(), value.as_bytes())?;
     }
     let chunk = request.body();
     if !chunk.end_of_stream {
@@ -354,8 +354,8 @@ pub fn send_request(request: Request) -> Response {
     } else if chunk.size > 16384 {
         panic!("the entire request body must be 16384 bytes or less");
     }
-    let response = crate::bulwark_host::set_request_body(request_id, &chunk.content);
-    Response::from(response)
+    let response = crate::bulwark_host::set_request_body(request_id, &chunk.content)?;
+    Ok(Response::from(response))
 }
 
 /// Returns the named state value retrieved from Redis.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -70,8 +70,6 @@ pub const NO_BODY: BodyChunk = BodyChunk {
     content: vec![],
 };
 
-// NOTE: `pub use` pattern would be better than inlined functions, but apparently that can't be rustdoc'd?
-
 // TODO: might need either get_remote_addr or an extension on the request for non-forwarded IP address
 
 /// Returns the incoming request.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -1,6 +1,6 @@
 use {
     std::{net::IpAddr, str, str::FromStr},
-    validator::{Validate, ValidationErrors},
+    validator::Validate,
 };
 
 // For some reason, doc-tests in this module trigger a linker error, so they're set to no_run
@@ -200,13 +200,15 @@ pub fn get_env_bytes(key: &str) -> Result<Vec<u8>, crate::Error> {
 /// # Arguments
 ///
 /// * `decision` - The [`Decision`] output of the plugin.
-pub fn set_decision(decision: Decision) -> Result<(), ValidationErrors> {
+pub fn set_decision(decision: Decision) -> Result<(), crate::Error> {
+    // Validate here because it should provide a better error than the one that the host will give.
     decision.validate()?;
     crate::bulwark_host::set_decision(DecisionInterface {
         accept: decision.accept,
         restrict: decision.restrict,
         unknown: decision.unknown,
-    });
+    })
+    .expect("should not be able to produce an invalid result");
     Ok(())
 }
 
@@ -227,7 +229,8 @@ pub fn set_accepted(value: f64) {
         }
         .scale()
         .into(),
-    );
+    )
+    .expect("should not be able to produce an invalid result");
 }
 
 /// Records a decision indicating that the plugin wants to restrict a request.
@@ -247,7 +250,8 @@ pub fn set_restricted(value: f64) {
         }
         .scale()
         .into(),
-    );
+    )
+    .expect("should not be able to produce an invalid result");
 }
 
 /// Records the tags the plugin wants to associate with its decision.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -179,9 +179,8 @@ pub fn get_config_value(key: &str) -> Option<Value> {
 /// # Arguments
 ///
 /// * `key` - The environment variable name. Case-sensitive.
-pub fn get_env(key: &str) -> String {
-    // TODO: this should return a result
-    String::from_utf8(crate::bulwark_host::get_env_bytes(key)).unwrap()
+pub fn get_env(key: &str) -> Result<String, crate::Error> {
+    Ok(String::from_utf8(crate::bulwark_host::get_env_bytes(key)?)?)
 }
 
 /// Returns a named environment variable value as bytes.
@@ -192,9 +191,8 @@ pub fn get_env(key: &str) -> String {
 /// # Arguments
 ///
 /// * `key` - The environment variable name. Case-sensitive.
-pub fn get_env_bytes(key: &str) -> Vec<u8> {
-    // TODO: this should return a result
-    crate::bulwark_host::get_env_bytes(key)
+pub fn get_env_bytes(key: &str) -> Result<Vec<u8>, crate::Error> {
+    Ok(crate::bulwark_host::get_env_bytes(key)?)
 }
 
 /// Records the decision value the plugin wants to return.

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -311,25 +311,23 @@ pub fn append_tags<I: IntoIterator<Item = V>, V: Into<String>>(tags: I) -> Vec<S
 /// Returns the combined decision, if available.
 ///
 /// Typically used in the feedback phase.
-pub fn get_combined_decision() -> Decision {
-    // TODO: Option<Decision> ?
-    crate::bulwark_host::get_combined_decision().into()
+pub fn get_combined_decision() -> Option<Decision> {
+    crate::bulwark_host::get_combined_decision().map(|decision| decision.into())
 }
 
 /// Returns the combined set of tags associated with a decision, if available.
 ///
 /// Typically used in the feedback phase.
 #[inline]
-pub fn get_combined_tags() -> Vec<String> {
+pub fn get_combined_tags() -> Option<Vec<String>> {
     crate::bulwark_host::get_combined_tags()
 }
 
 /// Returns the outcome of the combined decision, if available.
 ///
 /// Typically used in the feedback phase.
-pub fn get_outcome() -> Outcome {
-    // TODO: Option<Outcome> ?
-    crate::bulwark_host::get_outcome().into()
+pub fn get_outcome() -> Option<Outcome> {
+    crate::bulwark_host::get_outcome().map(|outcome| outcome.into())
 }
 
 /// Sends an outbound HTTP request.

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -83,10 +83,9 @@ world host-api {
   import set-decision: func(decision: decision-interface) -> result<_, decision-error>
   import set-tags: func(tags: list<string>)
   import append-tags: func(tags: list<string>) -> list<string>
-  // TODO: these 3 should be option
-  import get-combined-decision: func() -> decision-interface
-  import get-combined-tags: func() -> list<string>
-  import get-outcome: func() -> outcome-interface
+  import get-combined-decision: func() -> option<decision-interface>
+  import get-combined-tags: func() -> option<list<string>>
+  import get-outcome: func() -> option<outcome-interface>
 
   import get-remote-state: func(key: string) -> result<list<u8>, state-error>
   import set-remote-state: func(key: string, value: list<u8>) -> result<_, state-error>

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -88,7 +88,6 @@ world host-api {
   import get-combined-tags: func() -> list<string>
   import get-outcome: func() -> outcome-interface
 
-  // TODO: error handling
   import get-remote-state: func(key: string) -> result<list<u8>, state-error>
   import set-remote-state: func(key: string, value: list<u8>) -> result<_, state-error>
   import increment-remote-state: func(key: string) -> result<s64, state-error>
@@ -100,11 +99,10 @@ world host-api {
   import add-request-header: func(request-id: u64, name: string, value: list<u8>)
   import set-request-body: func(request-id: u64, body: list<u8>) -> response-interface
 
-  // TODO: error handling
-  import increment-rate-limit: func(key: string, delta: s64, window: s64) -> rate-interface
-  import check-rate-limit: func(key: string) -> rate-interface
-  import increment-breaker: func(key: string, success-delta: s64, failure-delta: s64, window: s64) -> breaker-interface
-  import check-breaker: func(key: string) -> breaker-interface
+  import increment-rate-limit: func(key: string, delta: s64, window: s64) -> result<rate-interface, state-error>
+  import check-rate-limit: func(key: string) -> result<rate-interface, state-error>
+  import increment-breaker: func(key: string, success-delta: s64, failure-delta: s64, window: s64) -> result<breaker-interface, state-error>
+  import check-breaker: func(key: string) -> result<breaker-interface, state-error>
 }
 world handlers {
   export on-request: func() -> result

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -91,9 +91,9 @@ world host-api {
   // TODO: error handling
   import get-remote-state: func(key: string) -> result<list<u8>, state-error>
   import set-remote-state: func(key: string, value: list<u8>) -> result<_, state-error>
-  import increment-remote-state: func(key: string) -> s64
-  import increment-remote-state-by: func(key: string, delta: s64) -> s64
-  import set-remote-ttl: func(key: string, ttl: s64)
+  import increment-remote-state: func(key: string) -> result<s64, state-error>
+  import increment-remote-state-by: func(key: string, delta: s64) -> result<s64, state-error>
+  import set-remote-ttl: func(key: string, ttl: s64) -> result<_, state-error>
 
   // TODO: condense to one function, add error handling
   import prepare-request: func(method: string, uri: string) -> u64

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -64,6 +64,10 @@ world host-api {
   variant param-error {
     json(string),
   }
+  variant state-error {
+    permission(string),
+    remote(string),
+  }
 
   // TODO: many of these should return the result type; historically this wasn't supported but this should be fixed?
 
@@ -85,8 +89,8 @@ world host-api {
   import get-outcome: func() -> outcome-interface
 
   // TODO: error handling
-  import get-remote-state: func(key: string) -> list<u8>
-  import set-remote-state: func(key: string, value: list<u8>)
+  import get-remote-state: func(key: string) -> result<list<u8>, state-error>
+  import set-remote-state: func(key: string, value: list<u8>) -> result<_, state-error>
   import increment-remote-state: func(key: string) -> s64
   import increment-remote-state-by: func(key: string, delta: s64) -> s64
   import set-remote-ttl: func(key: string, ttl: s64)

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -85,7 +85,7 @@ world host-api {
   import get-env-bytes: func(key: string) -> result<list<u8>, env-error>
 
   import get-request: func() -> request-interface
-  import get-response: func() -> response-interface
+  import get-response: func() -> option<response-interface>
   import get-client-ip: func() -> option<ip-interface>
 
   import set-decision: func(decision: decision-interface) -> result<_, decision-error>

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -61,12 +61,15 @@ world host-api {
   variant decision-error {
     invalid(string),
   }
+  variant param-error {
+    json(string),
+  }
 
   // TODO: many of these should return the result type; historically this wasn't supported but this should be fixed?
 
   import get-config: func() -> list<u8>
-  import get-param-value: func(key: string) -> list<u8>
-  import set-param-value: func(key: string, value: list<u8>)
+  import get-param-value: func(key: string) -> result<list<u8>, param-error>
+  import set-param-value: func(key: string, value: list<u8>) -> result<_, param-error>
   import get-env-bytes: func(key: string) -> result<list<u8>, env-error>
 
   import get-request: func() -> request-interface
@@ -76,21 +79,24 @@ world host-api {
   import set-decision: func(decision: decision-interface) -> result<_, decision-error>
   import set-tags: func(tags: list<string>)
   import append-tags: func(tags: list<string>) -> list<string>
+  // TODO: these 3 should be option
   import get-combined-decision: func() -> decision-interface
   import get-combined-tags: func() -> list<string>
   import get-outcome: func() -> outcome-interface
 
+  // TODO: error handling
   import get-remote-state: func(key: string) -> list<u8>
   import set-remote-state: func(key: string, value: list<u8>)
   import increment-remote-state: func(key: string) -> s64
   import increment-remote-state-by: func(key: string, delta: s64) -> s64
   import set-remote-ttl: func(key: string, ttl: s64)
 
-  // TODO: condense to one function
+  // TODO: condense to one function, add error handling
   import prepare-request: func(method: string, uri: string) -> u64
   import add-request-header: func(request-id: u64, name: string, value: list<u8>)
   import set-request-body: func(request-id: u64, body: list<u8>) -> response-interface
 
+  // TODO: error handling
   import increment-rate-limit: func(key: string, delta: s64, window: s64) -> rate-interface
   import check-rate-limit: func(key: string) -> rate-interface
   import increment-breaker: func(key: string, success-delta: s64, failure-delta: s64, window: s64) -> breaker-interface

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -68,6 +68,14 @@ world host-api {
     permission(string),
     remote(string),
   }
+  variant http-error {
+    permission(string),
+    invalid-method(string),
+    invalid-uri(string),
+    // TODO: remove after condense
+    missing-id(u64),
+    transmit(string),
+  }
 
   // TODO: many of these should return the result type; historically this wasn't supported but this should be fixed?
 
@@ -93,10 +101,10 @@ world host-api {
   import increment-remote-state-by: func(key: string, delta: s64) -> result<s64, state-error>
   import set-remote-ttl: func(key: string, ttl: s64) -> result<_, state-error>
 
-  // TODO: condense to one function, add error handling
-  import prepare-request: func(method: string, uri: string) -> u64
-  import add-request-header: func(request-id: u64, name: string, value: list<u8>)
-  import set-request-body: func(request-id: u64, body: list<u8>) -> response-interface
+  // TODO: condense to one function
+  import prepare-request: func(method: string, uri: string) -> result<u64, http-error>
+  import add-request-header: func(request-id: u64, name: string, value: list<u8>) -> result<_, http-error>
+  import set-request-body: func(request-id: u64, body: list<u8>) -> result<response-interface, http-error>
 
   import increment-rate-limit: func(key: string, delta: s64, window: s64) -> result<rate-interface, state-error>
   import check-rate-limit: func(key: string) -> result<rate-interface, state-error>

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -58,6 +58,9 @@ world host-api {
     not-unicode(string),
     permission(string),
   }
+  variant decision-error {
+    invalid(string),
+  }
 
   // TODO: many of these should return the result type; historically this wasn't supported but this should be fixed?
 
@@ -70,7 +73,7 @@ world host-api {
   import get-response: func() -> response-interface
   import get-client-ip: func() -> option<ip-interface>
 
-  import set-decision: func(decision: decision-interface)
+  import set-decision: func(decision: decision-interface) -> result<_, decision-error>
   import set-tags: func(tags: list<string>)
   import append-tags: func(tags: list<string>) -> list<string>
   import get-combined-decision: func() -> decision-interface

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -53,13 +53,18 @@ world host-api {
     consecutive-failures: s64,
     expiration: s64,
   }
+  variant env-error {
+    missing(string),
+    not-unicode(string),
+    permission(string),
+  }
 
   // TODO: many of these should return the result type; historically this wasn't supported but this should be fixed?
 
   import get-config: func() -> list<u8>
   import get-param-value: func(key: string) -> list<u8>
   import set-param-value: func(key: string, value: list<u8>)
-  import get-env-bytes: func(key: string) -> list<u8>
+  import get-env-bytes: func(key: string) -> result<list<u8>, env-error>
 
   import get-request: func() -> request-interface
   import get-response: func() -> response-interface


### PR DESCRIPTION
Fixes #36.

API calls that could fail should largely now return a `Result` instead of panicking. Additionally cleans up some similar API calls that now return `Option` types where appropriate.