### PR TITLE
Remove wildcard dependency

### DIFF
--- a/crates/wasm-host/Cargo.toml
+++ b/crates/wasm-host/Cargo.toml
@@ -43,7 +43,7 @@ validator = { version = "0.16" }
 wasi-cap-std-sync = { version = "10" }
 wit-component = "0.11.0"
 wat = "1.0.57"
-tokio-test = "*"
+tokio-test = "0.4.2"
 
 [build-dependencies]
 reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }


### PR DESCRIPTION
Wildcards are disallowed for published crates.