### PR TITLE
Implement handling for request and response bodies

### DIFF
--- a/crates/ext-processor/examples/envoy.yaml
+++ b/crates/ext-processor/examples/envoy.yaml
@@ -48,7 +48,11 @@ static_resources:
       connect_timeout: 0.25s
       type: STATIC
       lb_policy: ROUND_ROBIN
-      http2_protocol_options: {}
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       load_assignment:
         cluster_name: interior
         endpoints:
@@ -63,7 +67,11 @@ static_resources:
       connect_timeout: 0.25s
       type: STATIC
       lb_policy: ROUND_ROBIN
-      http2_protocol_options: {}
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       load_assignment:
         cluster_name: bulwark
         endpoints:

--- a/crates/ext-processor/src/errors.rs
+++ b/crates/ext-processor/src/errors.rs
@@ -26,7 +26,7 @@ pub enum PrepareRequestError {
     MissingAuthority,
     #[error("missing http path pseudo-header")]
     MissingPath,
-    #[error("missing envoy headers")]
+    #[error("no headers received from envoy")]
     MissingHeaders,
 }
 

--- a/crates/ext-processor/src/errors.rs
+++ b/crates/ext-processor/src/errors.rs
@@ -10,10 +10,24 @@ pub enum PluginGroupInstantiationError {
     PluginInstantiation(#[from] PluginInstantiationError),
 }
 
+/// Returned when the Envoy external processor is unable to handle an incoming message successfully.
+#[derive(thiserror::Error, Debug)]
+pub enum HandlerError {
+    #[error(transparent)]
+    PluginInstantiation(#[from] PluginGroupInstantiationError),
+    #[error(transparent)]
+    Request(#[from] RequestError),
+    #[error(transparent)]
+    Response(#[from] ResponseError),
+    // TODO: remove once default routes are implemented
+    #[error(transparent)]
+    RouteMatch(#[from] matchit::MatchError),
+}
+
 /// Returned when trying to assemble a [`Request`](bulwark_wasm_sdk::Request) struct and Envoy sends missing
 /// or invalid information or an [HTTP error](http::Error) occurs.
 #[derive(thiserror::Error, Debug)]
-pub enum PrepareRequestError {
+pub enum RequestError {
     #[error(transparent)]
     InvalidMethod(#[from] http::method::InvalidMethod),
     #[error(transparent)]
@@ -33,7 +47,7 @@ pub enum PrepareRequestError {
 /// Returned when trying to assemble a [`Response`](bulwark_wasm_sdk::Response) struct and Envoy sends missing
 /// or invalid information or an [HTTP error](http::Error) occurs.
 #[derive(thiserror::Error, Debug)]
-pub enum PrepareResponseError {
+pub enum ResponseError {
     #[error(transparent)]
     Http(#[from] http::Error),
     #[error("missing http status pseudo-header")]

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -400,7 +400,7 @@ impl BulwarkProcessor {
         timeout_duration: std::time::Duration,
     ) {
         let mut init_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let init_phase_child_span = tracing::info_span!("execute on_init",);
             init_phase_tasks.spawn(
                 timeout(timeout_duration, async move {
@@ -439,7 +439,7 @@ impl BulwarkProcessor {
         timeout_duration: std::time::Duration,
     ) -> DecisionComponents {
         Self::execute_request_enrichment_phase(plugin_instances.clone(), timeout_duration).await;
-        Self::execute_request_decision_phase(plugin_instances.clone(), timeout_duration).await
+        Self::execute_request_decision_phase(plugin_instances, timeout_duration).await
     }
 
     async fn execute_request_enrichment_phase(
@@ -447,7 +447,7 @@ impl BulwarkProcessor {
         timeout_duration: std::time::Duration,
     ) {
         let mut enrichment_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let enrichment_phase_child_span = tracing::info_span!("execute on_request",);
             enrichment_phase_tasks.spawn(
                 timeout(timeout_duration, async move {
@@ -487,7 +487,7 @@ impl BulwarkProcessor {
     ) -> DecisionComponents {
         let decision_components = Arc::new(Mutex::new(Vec::with_capacity(plugin_instances.len())));
         let mut decision_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let decision_phase_child_span = tracing::info_span!("execute on_request_decision",);
             let decision_components = decision_components.clone();
             decision_phase_tasks.spawn(
@@ -570,7 +570,7 @@ impl BulwarkProcessor {
     ) -> DecisionComponents {
         let decision_components = Arc::new(Mutex::new(Vec::with_capacity(plugin_instances.len())));
         let mut decision_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let decision_phase_child_span =
                 tracing::info_span!("execute on_request_body_decision",);
             {
@@ -660,7 +660,7 @@ impl BulwarkProcessor {
     ) -> DecisionComponents {
         let decision_components = Arc::new(Mutex::new(Vec::with_capacity(plugin_instances.len())));
         let mut response_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let response_phase_child_span = tracing::info_span!("execute on_response_decision",);
             {
                 // Make sure the plugin instance knows about the response
@@ -749,7 +749,7 @@ impl BulwarkProcessor {
     ) -> DecisionComponents {
         let decision_components = Arc::new(Mutex::new(Vec::with_capacity(plugin_instances.len())));
         let mut response_phase_tasks = JoinSet::new();
-        for plugin_instance in plugin_instances.clone() {
+        for plugin_instance in plugin_instances {
             let response_phase_child_span =
                 tracing::info_span!("execute on_response_body_decision",);
             {
@@ -1000,7 +1000,7 @@ impl BulwarkProcessor {
                 )
                 .await,
                 thresholds,
-                plugin_instances.clone(),
+                plugin_instances,
                 timeout_duration,
             )
             .await;
@@ -1015,7 +1015,7 @@ impl BulwarkProcessor {
                 Self::execute_response_phase(plugin_instances.clone(), http_resp, timeout_duration)
                     .await,
                 thresholds,
-                plugin_instances.clone(),
+                plugin_instances,
                 timeout_duration,
             )
             .await;
@@ -1104,7 +1104,7 @@ impl BulwarkProcessor {
                 Self::execute_response_phase(plugin_instances.clone(), http_resp, timeout_duration)
                     .await,
                 thresholds,
-                plugin_instances.clone(),
+                plugin_instances,
                 timeout_duration,
             )
             .await;
@@ -1208,7 +1208,7 @@ impl BulwarkProcessor {
                 )
                 .await,
                 thresholds,
-                plugin_instances.clone(),
+                plugin_instances,
                 timeout_duration,
             )
             .await;

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -227,12 +227,11 @@ impl BulwarkProcessor {
             let request_uri = Self::get_header_value(&header_msg.headers, ":path")
                 .ok_or(PrepareRequestError::MissingPath)?;
             let mut request = http::Request::builder();
-            // TODO: read the request body
-            let request_chunk = bulwark_wasm_sdk::BodyChunk {
-                end_of_stream: header_msg.end_of_stream,
-                size: 0,
-                start: 0,
-                content: vec![],
+            let request_chunk = if header_msg.end_of_stream {
+                bulwark_wasm_sdk::NO_BODY
+            } else {
+                // Have to obtain this from envoy later if we need it
+                bulwark_wasm_sdk::UNAVAILABLE_BODY
             };
             // No current access to HTTP version information via Envoy external processor
             request = request.method(method).uri(request_uri);
@@ -275,12 +274,11 @@ impl BulwarkProcessor {
                 .ok_or(PrepareResponseError::MissingStatus)?;
 
             let mut response = http::Response::builder();
-            // TODO: read the response body
-            let response_chunk = bulwark_wasm_sdk::BodyChunk {
-                end_of_stream: header_msg.end_of_stream,
-                size: 0,
-                start: 0,
-                content: vec![],
+            let response_chunk = if header_msg.end_of_stream {
+                bulwark_wasm_sdk::NO_BODY
+            } else {
+                // Have to obtain this from envoy later if we need it
+                bulwark_wasm_sdk::UNAVAILABLE_BODY
             };
             response = response.status(status);
             match &header_msg.headers {

--- a/crates/wasm-sdk-macros/src/lib.rs
+++ b/crates/wasm-sdk-macros/src/lib.rs
@@ -3,18 +3,198 @@ use proc_macro2::Span;
 use quote::{quote, quote_spanned};
 use syn::{
     parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, Attribute, Ident,
-    ItemFn, ItemImpl, LitStr, ReturnType, Signature, Visibility,
+    ItemFn, ItemImpl, LitBool, LitStr, ReturnType, Signature, Visibility,
 };
 extern crate proc_macro;
 
+/// The `bulwark_plugin` attribute generates default implementations for all handler traits in a module
+/// and produces friendly errors for common mistakes.
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the input token stream as an impl, or return an error.
+    let raw_impl = parse_macro_input!(input as ItemImpl);
+
+    // The trait must be specified by the developer even though there's only one valid value.
+    // If we inject it, that leads to a very surprising result when developers try to define helper functions
+    // in the same struct impl and can't because it's really a trait impl.
+    if let Some((_, path, _)) = raw_impl.trait_ {
+        let trait_name = path.get_ident().map_or(String::new(), |id| id.to_string());
+        if &trait_name != "Handlers" {
+            return syn::Error::new(
+                path.span(),
+                format!(
+                    "`bulwark_plugin` encountered unexpected trait `{}` for the impl",
+                    trait_name
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+    } else {
+        return syn::Error::new(
+            raw_impl.self_ty.span(),
+            "`bulwark_plugin` requires an impl for the `Handlers` trait",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let struct_type = &raw_impl.self_ty;
+    let mut init_handler_found = false;
+    let mut request_body_handler_found = false;
+    let mut response_body_handler_found = false;
+
+    let mut handlers = vec![
+        "on_request",
+        "on_request_decision",
+        "on_response_decision",
+        "on_request_body_decision",
+        "on_response_body_decision",
+        "on_decision_feedback",
+    ];
+
+    let mut new_items = Vec::with_capacity(raw_impl.items.len());
+    for item in &raw_impl.items {
+        if let syn::ImplItem::Fn(iifn) = item {
+            match iifn.sig.ident.to_string().as_str() {
+                "on_init" => init_handler_found = true,
+                "on_request_body_decision" => request_body_handler_found = true,
+                "on_response_body_decision" => response_body_handler_found = true,
+                _ => {}
+            }
+            let initial_len = handlers.len();
+            // Find and record the implemented handlers, removing any we find from the list above.
+            handlers.retain(|h| *h != iifn.sig.ident.to_string().as_str());
+            // Verify that any functions with a handler name we find have set the `handler` attribute.
+            let mut use_original_item = true;
+            if handlers.len() < initial_len {
+                let mut handler_attr_found = false;
+                for attr in &iifn.attrs {
+                    if let Some(ident) = attr.meta.path().get_ident() {
+                        if ident.to_string().as_str() == "handler" {
+                            handler_attr_found = true;
+                            break;
+                        }
+                    }
+                }
+                if !handler_attr_found {
+                    use_original_item = false;
+                    let mut new_iifn = iifn.clone();
+                    new_iifn.attrs.push(parse_quote! {
+                        #[handler]
+                    });
+                    new_items.push(syn::ImplItem::Fn(new_iifn));
+                }
+            }
+            if use_original_item {
+                new_items.push(item.clone());
+            }
+        } else {
+            new_items.push(item.clone());
+        }
+    }
+
+    // Define the missing handlers with no-op defaults
+    let noop_handlers = handlers
+        .iter()
+        .map(|handler_name| {
+            let handler_ident = Ident::new(handler_name, Span::call_site());
+            quote! {
+                #[handler]
+                fn #handler_ident() -> Result {
+                    Ok(())
+                }
+            }
+        })
+        .collect::<Vec<proc_macro2::TokenStream>>();
+
+    let init_handler = if init_handler_found {
+        // Empty token stream if an init handler was already defined, we'll generate nothing and use that instead
+        quote! {}
+    } else {
+        let receive_request_body = LitBool::new(request_body_handler_found, Span::call_site());
+        let receive_response_body = LitBool::new(response_body_handler_found, Span::call_site());
+        quote! {
+            #[handler]
+            fn on_init() -> Result {
+                receive_request_body(#receive_request_body);
+                receive_response_body(#receive_response_body);
+                Ok(())
+            }
+        }
+    };
+
+    let output = quote! {
+        impl bulwark_wasm_sdk::handlers::Handlers for #struct_type {
+            #init_handler
+            #(#new_items)*
+            #(#noop_handlers)*
+        }
+        const _: () = {
+            #[doc(hidden)]
+            #[export_name = "on-init"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_init() -> i32 {
+                handlers::call_on_init::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-request"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_request() -> i32 {
+                handlers::call_on_request::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-request-decision"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_request_decision() -> i32 {
+                handlers::call_on_request_decision::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-response-decision"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_response_decision() -> i32 {
+                handlers::call_on_response_decision::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-request-body-decision"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_request_body_decision() -> i32 {
+                handlers::call_on_request_body_decision::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-response-body-decision"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_response_body_decision() -> i32 {
+                handlers::call_on_response_body_decision::<#struct_type>()
+            }
+            #[doc(hidden)]
+            #[export_name = "on-decision-feedback"]
+            #[allow(non_snake_case)]
+            unsafe extern "C" fn __export_handlers_on_decision_feedback() -> i32 {
+                handlers::call_on_decision_feedback::<#struct_type>()
+            }
+        };
+    };
+
+    output.into()
+}
+
 /// The `handler` attribute makes the associated function into a Bulwark event handler.
 ///
-/// The function must take no parameters and return a `bulwark_wasm_sdk::Result`. It may only be
+/// The `handler` attribute is normally applied automatically by the `bulwark_plugin` macro and
+/// need not be specified explicitly.
+///
+/// The associated function must take no parameters and return a `bulwark_wasm_sdk::Result`. It may only be
 /// named one of the following:
+/// - `on_init`
 /// - `on_request`
 /// - `on_request_decision`
 /// - `on_response_decision`
+/// - `on_request_body_decision`
+/// - `on_response_body_decision`
 /// - `on_decision_feedback`
+#[doc(hidden)]
 #[proc_macro_attribute]
 pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the input token stream as a free-standing function, or return an error.
@@ -49,7 +229,13 @@ fn {}() -> Result {{
     let output;
 
     match name.to_string().as_str() {
-        "on_request" | "on_request_decision" | "on_response_decision" | "on_decision_feedback" => {
+        "on_init"
+        | "on_request"
+        | "on_request_decision"
+        | "on_response_decision"
+        | "on_request_body_decision"
+        | "on_response_body_decision"
+        | "on_decision_feedback" => {
             output = quote_spanned! {inner_fn.span() =>
                 #(#attrs)*
                 #sig {
@@ -70,9 +256,12 @@ fn {}() -> Result {{
                 inner_fn.sig.span(),
                 "`handler` expects a function named one of:
                 
+- `on_init`
 - `on_request`
 - `on_request_decision`
 - `on_response_decision`
+- `on_request_body_decision`
+- `on_response_body_decision`
 - `on_decision_feedback`
 ",
             )
@@ -142,131 +331,4 @@ fn inner_fn_info(mut inner_handler: ItemFn) -> (Ident, ItemFn) {
         .attrs
         .retain(|attr| !attr.path().is_ident("no_mangle"));
     (name, inner_handler)
-}
-
-/// The `bulwark_plugin` attribute generates default implementations for all handler traits in a module
-/// and produces friendly errors for common mistakes.
-#[doc(hidden)]
-#[proc_macro_attribute]
-pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
-    // Parse the input token stream as an impl, or return an error.
-    let raw_impl = parse_macro_input!(input as ItemImpl);
-
-    // The trait must be specified by the developer even though there's only one valid value.
-    // If we inject it, that leads to a very surprising result when developers try to define helper functions
-    // in the same struct impl and can't because it's really a trait impl.
-    if let Some((_, path, _)) = raw_impl.trait_ {
-        let trait_name = path.get_ident().map_or(String::new(), |id| id.to_string());
-        if &trait_name != "Handlers" {
-            return syn::Error::new(
-                path.span(),
-                format!(
-                    "`bulwark_plugin` encountered unexpected trait `{}` for the impl",
-                    trait_name
-                ),
-            )
-            .to_compile_error()
-            .into();
-        }
-    } else {
-        return syn::Error::new(
-            raw_impl.self_ty.span(),
-            "`bulwark_plugin` requires an impl for the `Handlers` trait",
-        )
-        .to_compile_error()
-        .into();
-    }
-
-    let struct_type = &raw_impl.self_ty;
-
-    let mut handlers = vec![
-        "on_request",
-        "on_request_decision",
-        "on_response_decision",
-        "on_decision_feedback",
-    ];
-
-    let mut new_items = Vec::with_capacity(raw_impl.items.len());
-    for item in &raw_impl.items {
-        if let syn::ImplItem::Fn(iifn) = item {
-            let initial_len = handlers.len();
-            // Find and record the implemented handlers, removing any we find from the list above.
-            handlers.retain(|h| *h != iifn.sig.ident.to_string().as_str());
-            // Verify that any functions with a handler name we find have set the `handler` attribute.
-            let mut use_original_item = true;
-            if handlers.len() < initial_len {
-                let mut handler_attr_found = false;
-                for attr in &iifn.attrs {
-                    if let Some(ident) = attr.meta.path().get_ident() {
-                        if ident.to_string().as_str() == "handler" {
-                            handler_attr_found = true;
-                            break;
-                        }
-                    }
-                }
-                if !handler_attr_found {
-                    use_original_item = false;
-                    let mut new_iifn = iifn.clone();
-                    new_iifn.attrs.push(parse_quote! {
-                        #[handler]
-                    });
-                    new_items.push(syn::ImplItem::Fn(new_iifn));
-                }
-            }
-            if use_original_item {
-                new_items.push(item.clone());
-            }
-        } else {
-            new_items.push(item.clone());
-        }
-    }
-
-    // Define the missing handlers with no-op defaults
-    let noop_handlers = handlers
-        .iter()
-        .map(|handler_name| {
-            let handler_ident = Ident::new(handler_name, Span::call_site());
-            quote! {
-                #[handler]
-                fn #handler_ident() -> Result {
-                    Ok(())
-                }
-            }
-        })
-        .collect::<Vec<proc_macro2::TokenStream>>();
-
-    let output = quote! {
-        impl bulwark_wasm_sdk::handlers::Handlers for #struct_type {
-            #(#new_items)*
-            #(#noop_handlers)*
-        }
-        const _: () = {
-            #[doc(hidden)]
-            #[export_name = "on-request"]
-            #[allow(non_snake_case)]
-            unsafe extern "C" fn __export_handlers_on_request() -> i32 {
-                handlers::call_on_request::<#struct_type>()
-            }
-            #[doc(hidden)]
-            #[export_name = "on-request-decision"]
-            #[allow(non_snake_case)]
-            unsafe extern "C" fn __export_handlers_on_request_decision() -> i32 {
-                handlers::call_on_request_decision::<#struct_type>()
-            }
-            #[doc(hidden)]
-            #[export_name = "on-response-decision"]
-            #[allow(non_snake_case)]
-            unsafe extern "C" fn __export_handlers_on_response_decision() -> i32 {
-                handlers::call_on_response_decision::<#struct_type>()
-            }
-            #[doc(hidden)]
-            #[export_name = "on-decision-feedback"]
-            #[allow(non_snake_case)]
-            unsafe extern "C" fn __export_handlers_on_decision_feedback() -> i32 {
-                handlers::call_on_decision_feedback::<#struct_type>()
-            }
-        };
-    };
-
-    output.into()
 }

--- a/crates/wasm-sdk-macros/src/lib.rs
+++ b/crates/wasm-sdk-macros/src/lib.rs
@@ -9,7 +9,6 @@ extern crate proc_macro;
 
 /// The `bulwark_plugin` attribute generates default implementations for all handler traits in a module
 /// and produces friendly errors for common mistakes.
-#[doc(hidden)]
 #[proc_macro_attribute]
 pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the input token stream as an impl, or return an error.

--- a/crates/wasm-sdk/src/from.rs
+++ b/crates/wasm-sdk/src/from.rs
@@ -14,6 +14,7 @@ impl From<Request> for crate::bulwark_host::RequestInterface {
                 .iter()
                 .map(|(name, value)| (name.to_string(), value.as_bytes().to_vec()))
                 .collect(),
+            body_received: request.body().received,
             chunk: request.body().content.clone(),
             chunk_start: request.body().start,
             chunk_length: request.body().size,
@@ -31,7 +32,8 @@ impl From<crate::bulwark_host::ResponseInterface> for Response {
         }
         builder
             .body(BodyChunk {
-                end_of_stream: true,
+                received: response.body_received,
+                end_of_stream: response.end_of_stream,
                 size: response.chunk.len().try_into().unwrap(),
                 start: 0,
                 content: response.chunk,
@@ -89,6 +91,7 @@ impl From<crate::bulwark_host::OutcomeInterface> for Outcome {
 impl From<&str> for BodyChunk {
     fn from(content: &str) -> Self {
         BodyChunk {
+            received: true,
             end_of_stream: true,
             size: content.len() as u64,
             start: 0,
@@ -100,6 +103,7 @@ impl From<&str> for BodyChunk {
 impl From<String> for BodyChunk {
     fn from(content: String) -> Self {
         BodyChunk {
+            received: true,
             end_of_stream: true,
             size: content.len() as u64,
             start: 0,
@@ -111,6 +115,7 @@ impl From<String> for BodyChunk {
 impl From<Vec<u8>> for BodyChunk {
     fn from(content: Vec<u8>) -> Self {
         BodyChunk {
+            received: true,
             end_of_stream: true,
             size: content.len() as u64,
             start: 0,

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -127,6 +127,32 @@ pub fn get_response() -> Option<Response> {
     )
 }
 
+/// Determines whether the `on_request_body_decision` handler will be called with a request body or not.
+///
+/// The [`bulwark_plugin`](bulwark_wasm_sdk_macros::bulwark_plugin) macro will automatically call this function
+/// within an auto-generated `on_init` handler. Normally, plugin authors do not need to call it directly.
+/// However, the default may be overriden if a plugin intends to cancel processing of the request body despite
+/// having a handler available for processing it.
+///
+/// However, if the `on_init` handler is replaced, this function will need to be called manually. Most plugins
+/// will not need to do this.
+pub fn receive_request_body(body: bool) {
+    crate::bulwark_host::receive_request_body(body)
+}
+
+/// Determines whether the `on_response_body_decision` handler will be called with a response body or not.
+///
+/// The [`bulwark_plugin`](bulwark_wasm_sdk_macros::bulwark_plugin) macro will automatically call this function
+/// within an auto-generated `on_init` handler. Normally, plugin authors do not need to call it directly.
+/// However, the default may be overriden if a plugin intends to cancel processing of the response body despite
+/// having a handler available for processing it.
+///
+/// However, if the `on_init` handler is replaced, this function will need to be called manually. Most plugins
+/// will not need to do this.
+pub fn receive_response_body(body: bool) {
+    crate::bulwark_host::receive_response_body(body)
+}
+
 /// Returns the originating client's IP address, if available.
 pub fn get_client_ip() -> Option<IpAddr> {
     crate::bulwark_host::get_client_ip().map(|ip| ip.into())

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -55,6 +55,7 @@ pub enum BreakerDelta {
 /// more tolerant to trunctation are recommended in such cases. There will be some situations where this limitation
 /// prevents useful parsing entirely and plugins may need to make use of the `unknown` result value to express this.
 pub struct BodyChunk {
+    pub received: bool,
     pub end_of_stream: bool,
     pub size: u64,
     pub start: u64,
@@ -64,6 +65,16 @@ pub struct BodyChunk {
 
 /// An empty HTTP body
 pub const NO_BODY: BodyChunk = BodyChunk {
+    received: true,
+    end_of_stream: true,
+    size: 0,
+    start: 0,
+    content: vec![],
+};
+
+/// An unavailable HTTP body
+pub const UNAVAILABLE_BODY: BodyChunk = BodyChunk {
+    received: false,
     end_of_stream: true,
     size: 0,
     start: 0,
@@ -94,6 +105,7 @@ pub fn get_request() -> Request {
     }
     request
         .body(BodyChunk {
+            received: raw_request.body_received,
             content: chunk,
             size: raw_request.chunk_length,
             start: raw_request.chunk_start,
@@ -116,6 +128,7 @@ pub fn get_response() -> Option<Response> {
     Some(
         response
             .body(BodyChunk {
+                received: raw_response.body_received,
                 content: chunk,
                 size: raw_response.chunk_length,
                 start: raw_response.chunk_start,

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -11,6 +11,7 @@ world host-api {
     uri: string,
     version: string,
     headers: list<tuple<string,list<u8>>>,
+    body-received: bool,
     chunk: list<u8>,
     chunk-start: u64,
     chunk-length: u64,
@@ -19,6 +20,7 @@ world host-api {
   record response-interface {
     status: u32,
     headers: list<tuple<string,list<u8>>>,
+    body-received: bool,
     chunk: list<u8>,
     chunk-start: u64,
     chunk-length: u64,

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -1,6 +1,8 @@
 package bulwark:plugin
 
 // TODO: See https://github.com/WebAssembly/wasi-http for a more complete canonical http component interface
+// TODO: request/response bodies might be better handled as resource types?
+// see: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#item-resource
 
 world host-api {
   // TODO: should these strings all be list<u8>?
@@ -83,6 +85,8 @@ world host-api {
 
   import get-request: func() -> request-interface
   import get-response: func() -> option<response-interface>
+  import receive-request-body: func(body: bool)
+  import receive-response-body: func(body: bool)
   import get-client-ip: func() -> option<ip-interface>
 
   import set-decision: func(decision: decision-interface) -> result<_, decision-error>
@@ -106,8 +110,11 @@ world host-api {
   import check-breaker: func(key: string) -> result<breaker-interface, state-error>
 }
 world handlers {
+  export on-init: func() -> result
   export on-request: func() -> result
-  export on-response-decision: func() -> result
   export on-request-decision: func() -> result
+  export on-response-decision: func() -> result
+  export on-request-body-decision: func() -> result
+  export on-response-body-decision: func() -> result
   export on-decision-feedback: func() -> result
 }


### PR DESCRIPTION
Fixes #46.
Fixes #50.

There's quite a lot of subtly different but repetitive code starting to accumulate in the `service.rs` file. I'm not going to try to address it in this PR, but it's worth coming back and refactoring this.