### PR TITLE
Simplify plugin builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /crates/core/Cargo.lock
 /crates/wask-sdk/Cargo.lock
 /crates/wasm-sdk/examples/Cargo.lock
+/adapter/*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "axum",
  "bulwark-config",
  "bulwark-ext-processor",
+ "cargo_metadata",
  "chrono",
  "clap",
  "clap_complete",
@@ -295,6 +296,7 @@ dependencies = [
  "http",
  "hyper",
  "quoted-string",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -312,6 +314,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "wit-component",
 ]
 
 [[package]]
@@ -453,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cap-fs-ext"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +525,29 @@ dependencies = [
  "once_cell",
  "rustix",
  "winx",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -2908,6 +2943,9 @@ name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "wit-component",
+ "wit-component 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,12 @@ tower-layer = "0.3.2"
 chrono = { version = "0.4.26", features = ["serde"] }
 quoted-string = "0.6.1"
 tracing-core = "0.1.31"
+cargo_metadata = "0.15.4"
+wit-component = "0.11.0"
 
 [build-dependencies]
 clap_mangen = "0.2.5"
+reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+fn fetch_adapter() {
+    let dest_path = Path::new("./adapter");
+    let file_path = dest_path.join("wasi_snapshot_preview1.reactor.wasm");
+    let body = reqwest::blocking::get("https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasi_snapshot_preview1.reactor.wasm").unwrap().bytes().unwrap();
+    std::fs::write(file_path, body).unwrap();
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    fetch_adapter();
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,96 @@
+use crate::errors::BuildError;
+use cargo_metadata::Message;
+use cargo_metadata::{CargoOpt, MetadataCommand};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+pub fn plugin_name(path: impl AsRef<Path>) -> Result<String, BuildError> {
+    let path = path.as_ref();
+
+    let metadata = MetadataCommand::new()
+        .manifest_path(path.join("Cargo.toml"))
+        .exec()?;
+
+    let root = metadata.root_package().ok_or(BuildError::MissingMetadata)?;
+    Ok(root.name.clone())
+}
+
+pub fn wasm_filename(path: impl AsRef<Path>) -> Result<String, BuildError> {
+    let plugin_name = plugin_name(path)?;
+    Ok(format!("{}.wasm", plugin_name.replace("-", "_")))
+}
+
+fn adapt_wasm_output(wasm_bytes: Vec<u8>, adapter_bytes: Vec<u8>) -> Result<Vec<u8>, BuildError> {
+    let component = wit_component::ComponentEncoder::default()
+        .module(&wasm_bytes)
+        .map_err(|err| BuildError::Adapter(err.to_string()))?
+        .validate(true)
+        .adapter("wasi_snapshot_preview1", &adapter_bytes)
+        .map_err(|err| BuildError::Adapter(err.to_string()))?
+        .encode()
+        .map_err(|err| BuildError::Adapter(err.to_string()))?;
+
+    Ok(component.to_vec())
+}
+
+/// Builds a plugin.
+///
+/// Compiles the plugin with the `wasm32-wasi` target, and installs it if it is missing.
+/// Uses an embeded adapter WASM file to adapt from preview 1 to preview 2 for the component
+/// model.
+///
+/// Calls out to `cargo` via [`Command`], so `cargo` must be available on the path for this
+/// function to work.
+pub fn build_plugin(path: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<(), BuildError> {
+    // TODO: install wasm32-wasi target if missing
+    let adapter_bytes = include_bytes!("../adapter/wasi_snapshot_preview1.reactor.wasm");
+    let path = path.as_ref();
+    let output = output.as_ref();
+    let output_dir = output.parent().ok_or(BuildError::MissingParent)?;
+
+    let mut args = vec!["build", "--target=wasm32-wasi"];
+    // TODO: don't hard-code --release
+    let release = true;
+    if release {
+        args.push("--release");
+    }
+
+    let mut command = Command::new("cargo").args(&args).spawn()?;
+
+    let exit_status = command.wait()?;
+    if exit_status.success() {
+        let wasm_filename = wasm_filename(path)?;
+        let wasm_path = path
+            .join("target/wasm32-wasi")
+            .join(if release { "release" } else { "debug" })
+            .join(wasm_filename);
+        let wasm_bytes = std::fs::read(&wasm_path)
+            .map_err(|err| BuildError::NotFound(wasm_path.to_string_lossy().to_string(), err))?;
+
+        let adapted_bytes = adapt_wasm_output(wasm_bytes, adapter_bytes.to_vec())?;
+        std::fs::create_dir_all(output_dir)?;
+        std::fs::write(output, adapted_bytes)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plugin_name() -> Result<(), Box<dyn std::error::Error>> {
+        let bulwark_plugin_name = plugin_name(std::env::current_dir()?)?;
+        assert_eq!(bulwark_plugin_name, "bulwark-cli");
+        Ok(())
+    }
+
+    #[test]
+    fn test_wasm_filename() -> Result<(), Box<dyn std::error::Error>> {
+        // Doesn't matter that this particular crate isn't a plugin, if it works here it'll work for a real plugin.
+        let wasm_filename = wasm_filename(std::env::current_dir()?)?;
+        assert_eq!(wasm_filename, "bulwark_cli.wasm");
+        Ok(())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,4 +13,20 @@ pub enum ServiceError {
 }
 
 #[derive(thiserror::Error, Debug)]
+pub enum BuildError {
+    #[error("missing file '{0}': {1}")]
+    NotFound(String, std::io::Error),
+    #[error("missing parent directory")]
+    MissingParent,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("error reading plugin metadata: {0}")]
+    CargoMetadata(#[from] cargo_metadata::Error),
+    #[error("missing plugin metadata")]
+    MissingMetadata,
+    #[error("error adapting wasm: {0}")]
+    Adapter(String),
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum AdminServiceError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,10 +20,14 @@ pub enum BuildError {
     MissingParent,
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("subprocess had non-zero exit status")]
+    SubprocessError,
     #[error("error reading plugin metadata: {0}")]
     CargoMetadata(#[from] cargo_metadata::Error),
     #[error("missing plugin metadata")]
     MissingMetadata,
+    #[error("missing required wasm32-wasi target")]
+    MissingTarget,
     #[error("error adapting wasm: {0}")]
     Adapter(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let output = output
                 .clone()
                 .unwrap_or(current_dir.join("dist").join(wasm_filename));
-            crate::build::build_plugin(&path, &output)?;
+            crate::build::build_plugin(&path, output)?;
         }
         None => todo!(),
     }


### PR DESCRIPTION
Fixes #30.

Assumes that `rustup` and `cargo` will be present, with the former not necessarily being a valid assumption. A follow-up task should address other installation environments seamlessly.