### PR TITLE
Current directory was missing from the sub process

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -109,7 +109,10 @@ pub(crate) fn build_plugin(
         args.push("--release");
     }
 
-    let mut command = Command::new("cargo").args(&args).spawn()?;
+    let mut command = Command::new("cargo")
+        .current_dir(path)
+        .args(&args)
+        .spawn()?;
 
     let exit_status = command.wait()?;
     if exit_status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,9 +279,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let path = path.clone().unwrap_or(current_dir.clone());
             let wasm_filename = crate::build::wasm_filename(&path)?;
             // Defaults to joining with the current working directory, not the input path
-            let output = output
+            let mut output = output
                 .clone()
-                .unwrap_or(current_dir.join("dist").join(wasm_filename));
+                .unwrap_or(current_dir.join("dist/plugins").join(&wasm_filename));
+            if output.is_dir() {
+                output = output.join(wasm_filename);
+            }
             crate::build::build_plugin(&path, output)?;
         }
         None => todo!(),


### PR DESCRIPTION
Fixes #95.

Also allows a directory to be specified for output instead of the full filename. This will allow the build command to infer the plugin filename as normal, but write the output to the specified directory. Could give arguably surprising behavior if the directory doesn't exist yet, but I think that's probably a reasonable trade-off? There's perhaps still some additional opportunity to reduce surprise here but I think that's something to optimize a little later on.