### PR TITLE
Reexport the json macro as a value macro

### DIFF
--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -9,6 +9,7 @@ use crate::bulwark_host::DecisionInterface;
 
 pub use crate::{Decision, Outcome};
 pub use http::{Extensions, Method, StatusCode, Uri, Version};
+pub use serde_json::json as value;
 pub use serde_json::{Map, Value};
 
 /// An HTTP request combines a head consisting of a [`Method`], [`Uri`], and headers with a [`BodyChunk`], which provides


### PR DESCRIPTION
Avoids plugin developers having to declare their own dependency on `serde_json` and somewhat confusingly call the `json!` macro when it doesn't appear from their viewpoint as though they're handling JSON since the JSON usage is hidden from them. This will be most relevant in unit tests.