### PR TITLE
Clap is needed for the CLI crate, not here

### DIFF
--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -18,7 +18,6 @@ bulwark-config = { path = "../config", version = "0.3.0" }
 bulwark-wasm-host = { path = "../wasm-host", version = "0.3.0" }
 bulwark-wasm-sdk = { path = "../wasm-sdk", version = "0.3.0" }
 bytes = "1"
-clap = { version = "4.4.3", features = ["derive"] }
 envoy-control-plane = { version = "0.4.0", features = ["grpc"] }
 futures = "0.3"
 json = "0.12.4"


### PR DESCRIPTION
Tiny change to drop an unused and unnecessary dependency.