### PR TITLE
The restrict field conflicts with the restrict keyword in C++

### DIFF
--- a/crates/wasm-host/src/plugin.rs
+++ b/crates/wasm-host/src/plugin.rs
@@ -128,8 +128,8 @@ impl From<IpAddr> for bulwark_host::IpInterface {
 impl From<DecisionInterface> for Decision {
     fn from(decision: DecisionInterface) -> Self {
         Decision {
-            accept: decision.accept,
-            restrict: decision.restrict,
+            accept: decision.accepted,
+            restrict: decision.restricted,
             unknown: decision.unknown,
         }
     }
@@ -138,8 +138,8 @@ impl From<DecisionInterface> for Decision {
 impl From<Decision> for DecisionInterface {
     fn from(decision: Decision) -> Self {
         DecisionInterface {
-            accept: decision.accept,
-            restrict: decision.restrict,
+            accepted: decision.accept,
+            restricted: decision.restrict,
             unknown: decision.unknown,
         }
     }

--- a/crates/wasm-sdk/src/from.rs
+++ b/crates/wasm-sdk/src/from.rs
@@ -60,8 +60,8 @@ impl From<crate::bulwark_host::IpInterface> for IpAddr {
 impl From<crate::bulwark_host::DecisionInterface> for Decision {
     fn from(decision: crate::bulwark_host::DecisionInterface) -> Self {
         Decision {
-            accept: decision.accept,
-            restrict: decision.restrict,
+            accept: decision.accepted,
+            restrict: decision.restricted,
             unknown: decision.unknown,
         }
     }
@@ -70,8 +70,8 @@ impl From<crate::bulwark_host::DecisionInterface> for Decision {
 impl From<Decision> for crate::bulwark_host::DecisionInterface {
     fn from(decision: Decision) -> Self {
         crate::bulwark_host::DecisionInterface {
-            accept: decision.accept,
-            restrict: decision.restrict,
+            accepted: decision.accept,
+            restricted: decision.restrict,
             unknown: decision.unknown,
         }
     }

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -253,8 +253,8 @@ pub fn set_decision(decision: Decision) -> Result<(), crate::Error> {
     // Validate here because it should provide a better error than the one that the host will give.
     decision.validate()?;
     crate::bulwark_host::set_decision(DecisionInterface {
-        accept: decision.accept,
-        restrict: decision.restrict,
+        accepted: decision.accept,
+        restricted: decision.restrict,
         unknown: decision.unknown,
     })
     .expect("should not be able to produce an invalid result");

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -31,8 +31,8 @@ world host-api {
     v6(tuple<u16, u16, u16, u16, u16, u16, u16, u16>),
   }
   record decision-interface {
-    accept: float64,
-    restrict: float64,
+    accepted: float64,
+    restricted: float64,
     unknown: float64,
   }
   enum outcome-interface {


### PR DESCRIPTION
We might also want to make the same change to the SDK version of the struct for consistency, but that's a more substantial breaking change instead of just requiring a recompile.