### PR TITLE
Converted to using workspace dependencies for anything shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,12 +420,10 @@ name = "bulwark-wasm-sdk"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "approx",
  "bulwark-decision",
  "bulwark-wasm-sdk-macros",
  "cfg-if 1.0.0",
  "http",
- "proc-macro2",
  "serde_json",
  "thiserror",
  "validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bulwark-cli"
 description = "Bulwark is a fast, modern, open-source web application security engine."
-version = "0.3.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 homepage = "https://bulwark.security/"
 repository = "https://github.com/bulwark-security/bulwark"
@@ -14,29 +14,31 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bulwark-ext-processor = { path = "crates/ext-processor", version = "0.3.0" }
-bulwark-config = { path = "crates/config", version = "0.3.0" }
-thiserror = "1.0.37"
+bulwark-config = { workspace = true }
+bulwark-ext-processor = { workspace = true }
+chrono = { workspace = true }
+envoy-control-plane = { workspace = true }
+http = { workspace = true }
+metrics = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+wit-component = { workspace = true }
+
+axum = { version = "0.6.18", features = ["http2"] }
+cargo_metadata = "0.18.1"
 clap = { version = "4.4.3", features = ["derive"] }
 clap_complete = "4.4.1"
-serde = { version = "1.0.149", features = ["std", "serde_derive"] }
-serde_json = "1.0.93"
-toml = { version = "0.8.6", features = ["preserve_order"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "tracing"] }
-envoy-control-plane = { version = "0.4.0", features = ["grpc"] }
-tonic = "0.6.2"
-tracing = "0.1.37"
-tracing-log = "0.2.0"
-tracing-opentelemetry = "0.22.0"
-tracing-forest = { version = "0.1.5", features = ["tokio", "chrono", "uuid"] }
-tracing-appender = "0.2.2"
-tracing-futures = { version = "0.2.5", features = ["tokio"] }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 color-eyre = "0.6.2"
-http = "0.2"
 hyper = { version = "0.14.25", features = ["server"] }
+metrics-exporter-prometheus = "0.12.1"
+metrics-exporter-statsd = "0.6.0"
+quoted-string = "0.6.1"
 tower = { version = "0.4.13", features = ["tokio", "tracing"] }
-axum = { version = "0.6.18", features = ["http2"] }
 tower-http = { version = "0.4.0", features = [
     "tokio",
     "trace",
@@ -44,18 +46,18 @@ tower-http = { version = "0.4.0", features = [
     "normalize-path",
 ] }
 tower-layer = "0.3.2"
-chrono = { version = "0.4.26", features = ["serde"] }
-quoted-string = "0.6.1"
+tracing-appender = "0.2.2"
 tracing-core = "0.1.31"
-cargo_metadata = "0.18.1"
-wit-component = "0.12.0"
-metrics-exporter-prometheus = "0.12.1"
-metrics-exporter-statsd = "0.6.0"
-metrics = "0.21.1"
+tracing-forest = { version = "0.1.5", features = ["tokio", "chrono", "uuid"] }
+tracing-futures = { version = "0.2.5", features = ["tokio"] }
+tracing-log = "0.2.0"
+tracing-opentelemetry = "0.22.0"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [build-dependencies]
+reqwest = { workspace = true }
+
 clap_mangen = "0.2.5"
-reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
 
 [workspace]
 members = [
@@ -66,6 +68,56 @@ members = [
     "crates/wasm-sdk-macros",
     "crates/decision",
 ]
+
+[workspace.package]
+version = "0.3.0"
+edition = "2021"
+# This should be no larger than the current stable release of Rust minus 2.
+rust-version = "1.72.0"
+
+[workspace.dependencies]
+# Internal dependencies
+bulwark-config = { path = "crates/config", version = "=0.3.0" }
+bulwark-decision = { path = "crates/decision", version = "=0.3.0" }
+bulwark-ext-processor = { path = "crates/ext-processor", version = "=0.3.0" }
+bulwark-wasm-host = { path = "crates/wasm-host", version = "=0.3.0" }
+bulwark-wasm-sdk = { path = "crates/wasm-sdk", version = "=0.3.0" }
+bulwark-wasm-sdk-macros = { path = "crates/wasm-sdk-macros", version = "=0.3.0" }
+
+# WASM dependencies
+wasi-cap-std-sync = { version = "11" }
+wasi-common = { version = "11" }
+wasmtime = { version = "11", features = ["component-model"] }
+wasmtime-types = { version = "11" }
+wasmtime-wasi = { version = "11" }
+wat = "1.0.57"
+wit-bindgen = "0.7.0"
+wit-component = "0.12.0"
+
+# Other shared external dependencies
+anyhow = "1"
+approx = "0.5"
+chrono = { version = "0.4.26", features = ["serde"] }
+envoy-control-plane = { version = "0.4.0", features = ["grpc"] }
+futures = "0.3"
+http = "0.2"
+metrics = "0.21.1"
+r2d2 = "0.8.10"
+redis = { version = "0.23.0", features = [
+    "tokio-comp",
+    "tokio-native-tls-comp",
+    "cluster",
+    "r2d2",
+] }
+reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
+serde = { version = "1.0.149", features = ["std", "serde_derive"] }
+serde_json = "1.0.93"
+thiserror = "1.0.37"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "tracing"] }
+toml = { version = "0.8.6", features = ["preserve_order"] }
+tonic = "0.6.2"
+tracing = "0.1.37"
+validator = { version = "0.16", features = ["derive"] }
 
 [profile.test]
 opt-level = 2

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,13 +14,15 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bulwark-decision = { path = "../decision", version = "0.3.0" }
-chrono = { version = "0.4.26", features = ["serde"] }
+bulwark-decision = { workspace = true }
+
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+validator = { workspace = true }
+
+itertools = "0.11.0"
 lazy_static = "1.4.0"
 regex = "1.9.1"
-serde = { version = "1.0.149", features = ["std", "serde_derive"] }
-serde_json = "1.0.93"
-thiserror = "1.0.37"
-toml = { version = "0.8.6", features = ["preserve_order"] }
-validator = { version = "0.16", features = ["derive"] }
-itertools = "0.11.0"

--- a/crates/decision/Cargo.toml
+++ b/crates/decision/Cargo.toml
@@ -14,11 +14,13 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-thiserror = "1.0.37"
-validator = { version = "0.16", features = ["derive"] }
-approx = "0.5"
+thiserror = { workspace = true }
+validator = { workspace = true }
+
 strum = "0.25"
 strum_macros = "0.25"
 
 [dev-dependencies]
+approx = { workspace = true }
+
 cfg-if = "1.0"

--- a/crates/decision/src/lib.rs
+++ b/crates/decision/src/lib.rs
@@ -6,6 +6,7 @@ mod errors;
 pub use decision::*;
 pub use errors::*;
 
+#[cfg(test)]
 #[allow(unused_imports)]
 #[macro_use]
 extern crate approx;

--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -14,32 +14,29 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bulwark-config = { path = "../config", version = "0.3.0" }
-bulwark-wasm-host = { path = "../wasm-host", version = "0.3.0" }
-bulwark-wasm-sdk = { path = "../wasm-sdk", version = "0.3.0" }
+bulwark-config = { workspace = true }
+bulwark-wasm-host = { workspace = true }
+bulwark-wasm-sdk = { workspace = true }
+
+envoy-control-plane = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+metrics = { workspace = true }
+r2d2 = { workspace = true }
+redis = { workspace = true }
+reqwest = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tracing = { workspace = true }
+
 bytes = "1"
-envoy-control-plane = { version = "0.4.0", features = ["grpc"] }
-futures = "0.3"
+forwarded-header-value = "0.1.1"
 json = "0.12.4"
+matchit = "0.7.0"
 prost = "0.12"
 prost-wkt = "=0.3.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tonic = "=0.6.2"
-http = "0.2"
-thiserror = "1.0.37"
-matchit = "0.7.0"
 sfv = "0.9.2"
-tracing = "0.1.37"
-redis = { version = "0.23.0", features = [
-    "tokio-comp",
-    "tokio-native-tls-comp",
-    "cluster",
-    "r2d2",
-] }
-r2d2 = "0.8.10"
-forwarded-header-value = "0.1.1"
-metrics = "0.21.1"
-reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
 
 [build-dependencies]
 # This dependency declaration and the other prost dependencies above prevent `cargo update`

--- a/crates/wasm-host/Cargo.toml
+++ b/crates/wasm-host/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bulwark-wasm-host"
 description = "The WebAssembly host environment for the Bulwark security engine."
-version = "0.3.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 homepage = "https://bulwark.security/"
 repository = "https://github.com/bulwark-security/bulwark"
@@ -14,37 +14,36 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bulwark-wasm-sdk = { path = "../wasm-sdk", version = "0.3.0" }
-bulwark-config = { path = "../config", version = "0.3.0" }
-thiserror = "1.0.37"
-anyhow = "1"
-wasi-common = { version = "11" }
-wasmtime = { version = "11", features = ["component-model"] }
-wasmtime-wasi = { version = "11" }
-wasmtime-types = { version = "11" }
-http = "0.2"
-redis = { version = "0.23.0", features = [
-    "tokio-comp",
-    "tokio-native-tls-comp",
-    "cluster",
-    "r2d2",
-] }
-r2d2 = "0.8.10"
-chrono = "0.4.23"
-serde = { version = "1.0.149", features = ["std", "serde_derive"] }
-serde_json = "1.0.93"
-reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
-url = "2.3.1"
-futures = "0.3"
+bulwark-config = { workspace = true }
+bulwark-wasm-sdk = { workspace = true }
+
+wasi-common = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-types = { workspace = true }
+wasmtime-wasi = { workspace = true }
+
+anyhow = { workspace = true }
+chrono = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+metrics = { workspace = true }
+r2d2 = { workspace = true }
+redis = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+validator = { workspace = true }
+
 async-trait = "0.1.68"
-validator = { version = "0.16" }
-metrics = "0.21.1"
+url = "2.3.1"
 
 [dev-dependencies]
-wasi-cap-std-sync = { version = "11" }
-wit-component = "0.12.0"
-wat = "1.0.57"
+wasi-cap-std-sync = { workspace = true }
+wat = { workspace = true }
+wit-component = { workspace = true }
+
 tokio-test = "0.4.2"
 
 [build-dependencies]
-reqwest = { version = "0.11.14", features = ["rustls-tls", "blocking"] }
+reqwest = { workspace = true }

--- a/crates/wasm-sdk/Cargo.toml
+++ b/crates/wasm-sdk/Cargo.toml
@@ -14,16 +14,16 @@ categories = ["wasm"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-bulwark-decision = { path = "../decision", version = "0.3.0" }
-bulwark-wasm-sdk-macros = { path = "../wasm-sdk-macros", version = "0.3.0" }
-thiserror = "1.0.37"
-anyhow = "1"
-http = "0.2"
-validator = { version = "0.16" }
-approx = "0.5"
-wit-bindgen = "0.7.0"
-serde_json = "1.0.93"
-proc-macro2 = "1.0.59"
+bulwark-decision = { workspace = true }
+bulwark-wasm-sdk-macros = { workspace = true }
+
+wit-bindgen = { workspace = true }
+
+anyhow = { workspace = true }
+http = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+validator = { workspace = true }
 
 [dev-dependencies]
 cfg-if = "1.0"

--- a/crates/wasm-sdk/src/lib.rs
+++ b/crates/wasm-sdk/src/lib.rs
@@ -31,7 +31,3 @@ pub use from::*;
 /// attribute for additional details on how to use this trait.
 pub use handlers::Handlers;
 pub use host_api::*;
-
-#[allow(unused_imports)]
-#[macro_use]
-extern crate approx;


### PR DESCRIPTION
Moved shared dependencies to top-level `Cargo.toml` file. Also pruned a few unused dependencies that had been previously missed.