### PR TITLE
The preferred subcommand seems to be add not install

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -62,7 +62,7 @@ fn installed_targets() -> Result<HashMap<String, bool>, BuildError> {
 
 fn install_wasm32_wasi_target() -> Result<(), BuildError> {
     let mut command = Command::new("rustup")
-        .args(["target", "install", "wasm32-wasi"])
+        .args(["target", "add", "wasm32-wasi"])
         .spawn()?;
     let exit_status = command.wait()?;
     if !exit_status.success() {


### PR DESCRIPTION
Switching from `install` to `add`, functionality should be identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified the Rust build script to change the command for adding a target, impacting the WASI target installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->