### PR TITLE
Rename remote state to simply redis

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -20,10 +20,12 @@ pub struct Config {
     pub service: Service,
     /// Configuration for the services being launched.
     pub runtime: Runtime,
-    /// Configuration for metrics collection.
-    pub metrics: Metrics,
+    /// Configuration for state managed by Bulwark plugins.
+    pub state: State,
     /// Configuration for the decision thresholds.
     pub thresholds: Thresholds,
+    /// Configuration for metrics collection.
+    pub metrics: Metrics,
     /// A list of configurations for individual plugins.
     pub plugins: Vec<Plugin>,
     /// A list of plugin groups that allows a plugin set to be loaded with a single reference.
@@ -72,10 +74,6 @@ pub struct Service {
     pub admin_port: u16,
     /// True if the admin service is enabled, false otherwise.
     pub admin_enabled: bool,
-    /// The URI for the external Redis state store.
-    pub redis_uri: Option<String>,
-    /// The size of the remote state connection pool.
-    pub redis_pool_size: u32,
     /// The number of trusted proxy hops expected to be exterior to Bulwark.
     ///
     /// This number does not include Bulwark or the proxy hosting it in the proxy hop count. Zero implies that
@@ -89,8 +87,6 @@ pub struct Service {
 pub const DEFAULT_PORT: u16 = 8089;
 /// The default [`Service::admin_port`] value.
 pub const DEFAULT_ADMIN_PORT: u16 = 8090;
-/// The default [`Service::redis_pool_size`] value.
-pub const DEFAULT_REDIS_POOL_SIZE: u32 = 16;
 
 impl Default for Service {
     /// Default service config
@@ -99,8 +95,6 @@ impl Default for Service {
             port: DEFAULT_PORT,
             admin_port: DEFAULT_ADMIN_PORT,
             admin_enabled: true,
-            redis_uri: None,
-            redis_pool_size: DEFAULT_REDIS_POOL_SIZE,
             proxy_hops: 0,
         }
     }
@@ -131,34 +125,24 @@ impl Default for Runtime {
     }
 }
 
-/// Configuration for metrics collection.
+/// Configuration for state managed by Bulwark plugins.
 #[derive(Debug, Clone)]
-pub struct Metrics {
-    pub statsd_host: Option<String>,
-    pub statsd_port: Option<u16>,
-    pub statsd_queue_size: usize,
-    pub statsd_buffer_size: usize,
-    pub statsd_prefix: String,
+pub struct State {
+    /// The URI for the external Redis state store.
+    pub redis_uri: Option<String>,
+    /// The size of the remote state connection pool.
+    pub redis_pool_size: u32,
 }
 
-/// The default [`Metrics::statsd_port`] value.
-pub const DEFAULT_STATSD_PORT: Option<u16> = Some(8125);
+/// The default [`Service::redis_pool_size`] value.
+pub const DEFAULT_REDIS_POOL_SIZE: u32 = 16;
 
-/// The default [`Metrics::statsd_queue_size`] value.
-pub const DEFAULT_STATSD_QUEUE_SIZE: usize = 5000;
-
-/// The default [`Metrics::statsd_buffer_size`] value.
-pub const DEFAULT_STATSD_BUFFER_SIZE: usize = 1024;
-
-impl Default for Metrics {
-    /// Default metrics config
+impl Default for State {
+    /// Default runtime config
     fn default() -> Self {
         Self {
-            statsd_host: None,
-            statsd_port: DEFAULT_STATSD_PORT,
-            statsd_queue_size: DEFAULT_STATSD_QUEUE_SIZE,
-            statsd_buffer_size: DEFAULT_STATSD_BUFFER_SIZE,
-            statsd_prefix: String::from(""),
+            redis_uri: None,
+            redis_pool_size: DEFAULT_REDIS_POOL_SIZE,
         }
     }
 }
@@ -199,6 +183,38 @@ impl Default for Thresholds {
             restrict: DEFAULT_RESTRICT_THRESHOLD,
             suspicious: DEFAULT_SUSPICIOUS_THRESHOLD,
             trust: DEFAULT_TRUST_THRESHOLD,
+        }
+    }
+}
+
+/// Configuration for metrics collection.
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub statsd_host: Option<String>,
+    pub statsd_port: Option<u16>,
+    pub statsd_queue_size: usize,
+    pub statsd_buffer_size: usize,
+    pub statsd_prefix: String,
+}
+
+/// The default [`Metrics::statsd_port`] value.
+pub const DEFAULT_STATSD_PORT: Option<u16> = Some(8125);
+
+/// The default [`Metrics::statsd_queue_size`] value.
+pub const DEFAULT_STATSD_QUEUE_SIZE: usize = 5000;
+
+/// The default [`Metrics::statsd_buffer_size`] value.
+pub const DEFAULT_STATSD_BUFFER_SIZE: usize = 1024;
+
+impl Default for Metrics {
+    /// Default metrics config
+    fn default() -> Self {
+        Self {
+            statsd_host: None,
+            statsd_port: DEFAULT_STATSD_PORT,
+            statsd_queue_size: DEFAULT_STATSD_QUEUE_SIZE,
+            statsd_buffer_size: DEFAULT_STATSD_BUFFER_SIZE,
+            statsd_prefix: String::from(""),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -73,9 +73,9 @@ pub struct Service {
     /// True if the admin service is enabled, false otherwise.
     pub admin_enabled: bool,
     /// The URI for the external Redis state store.
-    pub remote_state_uri: Option<String>,
+    pub redis_uri: Option<String>,
     /// The size of the remote state connection pool.
-    pub remote_state_pool_size: u32,
+    pub redis_pool_size: u32,
     /// The number of trusted proxy hops expected to be exterior to Bulwark.
     ///
     /// This number does not include Bulwark or the proxy hosting it in the proxy hop count. Zero implies that
@@ -89,8 +89,8 @@ pub struct Service {
 pub const DEFAULT_PORT: u16 = 8089;
 /// The default [`Service::admin_port`] value.
 pub const DEFAULT_ADMIN_PORT: u16 = 8090;
-/// The default [`Service::remote_state_pool_size`] value.
-pub const DEFAULT_REMOTE_STATE_POOL_SIZE: u32 = 16;
+/// The default [`Service::redis_pool_size`] value.
+pub const DEFAULT_REDIS_POOL_SIZE: u32 = 16;
 
 impl Default for Service {
     /// Default service config
@@ -99,8 +99,8 @@ impl Default for Service {
             port: DEFAULT_PORT,
             admin_port: DEFAULT_ADMIN_PORT,
             admin_enabled: true,
-            remote_state_uri: None,
-            remote_state_pool_size: DEFAULT_REMOTE_STATE_POOL_SIZE,
+            redis_uri: None,
+            redis_pool_size: DEFAULT_REDIS_POOL_SIZE,
             proxy_hops: 0,
         }
     }

--- a/crates/config/src/toml.rs
+++ b/crates/config/src/toml.rs
@@ -13,7 +13,7 @@ lazy_static! {
     static ref RE_VALID_REFERENCE: Regex = Regex::new(r"^[_a-z]+$").unwrap();
 }
 
-/// The TOML serialization for a Config structure.
+/// The TOML serialization for a [Config](crate::Config) structure.
 #[derive(Serialize, Deserialize, Default)]
 struct Config {
     #[serde(default)]
@@ -21,9 +21,11 @@ struct Config {
     #[serde(default)]
     runtime: Runtime,
     #[serde(default)]
-    metrics: Metrics,
+    state: State,
     #[serde(default)]
     thresholds: Thresholds,
+    #[serde(default)]
+    metrics: Metrics,
     #[serde(default, rename(serialize = "include", deserialize = "include"))]
     includes: Vec<Include>,
     #[serde(default, rename(serialize = "plugin", deserialize = "plugin"))]
@@ -34,7 +36,7 @@ struct Config {
     resources: Vec<Resource>,
 }
 
-/// The TOML serialization for a Service config structure.
+/// The TOML serialization for a [Service](crate::Service) config structure.
 #[derive(Serialize, Deserialize)]
 struct Service {
     #[serde(default = "default_port")]
@@ -43,10 +45,6 @@ struct Service {
     admin_port: u16,
     #[serde(default = "default_admin")]
     admin_enabled: bool,
-    #[serde(default = "default_redis_uri")]
-    redis_uri: Option<String>,
-    #[serde(default = "default_redis_pool_size")]
-    redis_pool_size: u32,
     #[serde(default = "default_proxy_hops")]
     proxy_hops: u8,
 }
@@ -70,16 +68,6 @@ fn default_admin() -> bool {
     true
 }
 
-/// The default for the network address to access remote state.
-fn default_redis_uri() -> Option<String> {
-    None
-}
-
-/// The default for the remote state connection pool size.
-fn default_redis_pool_size() -> u32 {
-    crate::DEFAULT_REDIS_POOL_SIZE
-}
-
 /// The default number of internal proxy hops expected in front of Bulwark.
 fn default_proxy_hops() -> u8 {
     0
@@ -91,8 +79,6 @@ impl Default for Service {
             port: default_port(),
             admin_port: default_admin_port(),
             admin_enabled: default_admin(),
-            redis_uri: default_redis_uri(),
-            redis_pool_size: default_redis_pool_size(),
             proxy_hops: default_proxy_hops(),
         }
     }
@@ -104,14 +90,12 @@ impl From<Service> for crate::Service {
             port: service.port,
             admin_port: service.admin_port,
             admin_enabled: service.admin_enabled,
-            redis_uri: service.redis_uri.clone(),
-            redis_pool_size: service.redis_pool_size,
             proxy_hops: service.proxy_hops,
         }
     }
 }
 
-/// The TOML serialization for a Runtime config structure.
+/// The TOML serialization for a [Runtime](crate::Runtime) config structure.
 #[derive(Serialize, Deserialize)]
 struct Runtime {
     #[serde(default = "default_max_concurrent_requests")]
@@ -152,59 +136,44 @@ impl From<Runtime> for crate::Runtime {
     }
 }
 
-/// The TOML serialization for a Metrics structure.
+/// The TOML serialization for a [State](crate::State) config structure.
 #[derive(Serialize, Deserialize)]
-struct Metrics {
-    #[serde(default)]
-    statsd_host: Option<String>,
-    #[serde(default = "default_statsd_port")]
-    statsd_port: Option<u16>,
-    #[serde(default = "default_statsd_queue_size")]
-    statsd_queue_size: usize,
-    #[serde(default = "default_statsd_buffer_size")]
-    statsd_buffer_size: usize,
-    #[serde(default)]
-    statsd_prefix: String,
+struct State {
+    #[serde(default = "default_redis_uri")]
+    redis_uri: Option<String>,
+    #[serde(default = "default_redis_pool_size")]
+    redis_pool_size: u32,
 }
 
-fn default_statsd_port() -> Option<u16> {
-    crate::DEFAULT_STATSD_PORT
+/// The default for the network address to access remote state.
+fn default_redis_uri() -> Option<String> {
+    None
 }
 
-fn default_statsd_queue_size() -> usize {
-    crate::DEFAULT_STATSD_QUEUE_SIZE
+/// The default for the remote state connection pool size.
+fn default_redis_pool_size() -> u32 {
+    crate::DEFAULT_REDIS_POOL_SIZE
 }
 
-fn default_statsd_buffer_size() -> usize {
-    crate::DEFAULT_STATSD_BUFFER_SIZE
-}
-
-impl Default for Metrics {
-    /// Default metrics config
+impl Default for State {
     fn default() -> Self {
         Self {
-            statsd_host: None,
-            statsd_port: default_statsd_port(),
-            statsd_queue_size: default_statsd_queue_size(),
-            statsd_buffer_size: default_statsd_buffer_size(),
-            statsd_prefix: String::from(""),
+            redis_uri: default_redis_uri(),
+            redis_pool_size: default_redis_pool_size(),
         }
     }
 }
 
-impl From<Metrics> for crate::Metrics {
-    fn from(metrics: Metrics) -> Self {
+impl From<State> for crate::State {
+    fn from(state: State) -> Self {
         Self {
-            statsd_host: metrics.statsd_host.clone(),
-            statsd_port: metrics.statsd_port,
-            statsd_queue_size: metrics.statsd_queue_size,
-            statsd_buffer_size: metrics.statsd_buffer_size,
-            statsd_prefix: metrics.statsd_prefix,
+            redis_uri: state.redis_uri,
+            redis_pool_size: state.redis_pool_size,
         }
     }
 }
 
-/// The TOML serialization for a Thresholds structure.
+/// The TOML serialization for a [Thresholds](crate::Thresholds) structure.
 #[derive(Serialize, Deserialize)]
 struct Thresholds {
     #[serde(default = "default_observe_only")]
@@ -259,7 +228,59 @@ impl From<Thresholds> for crate::Thresholds {
     }
 }
 
-/// The TOML serialization for an Include structure.
+/// The TOML serialization for a [Metrics](crate::Metrics) structure.
+#[derive(Serialize, Deserialize)]
+struct Metrics {
+    #[serde(default)]
+    statsd_host: Option<String>,
+    #[serde(default = "default_statsd_port")]
+    statsd_port: Option<u16>,
+    #[serde(default = "default_statsd_queue_size")]
+    statsd_queue_size: usize,
+    #[serde(default = "default_statsd_buffer_size")]
+    statsd_buffer_size: usize,
+    #[serde(default)]
+    statsd_prefix: String,
+}
+
+fn default_statsd_port() -> Option<u16> {
+    crate::DEFAULT_STATSD_PORT
+}
+
+fn default_statsd_queue_size() -> usize {
+    crate::DEFAULT_STATSD_QUEUE_SIZE
+}
+
+fn default_statsd_buffer_size() -> usize {
+    crate::DEFAULT_STATSD_BUFFER_SIZE
+}
+
+impl Default for Metrics {
+    /// Default metrics config
+    fn default() -> Self {
+        Self {
+            statsd_host: None,
+            statsd_port: default_statsd_port(),
+            statsd_queue_size: default_statsd_queue_size(),
+            statsd_buffer_size: default_statsd_buffer_size(),
+            statsd_prefix: String::from(""),
+        }
+    }
+}
+
+impl From<Metrics> for crate::Metrics {
+    fn from(metrics: Metrics) -> Self {
+        Self {
+            statsd_host: metrics.statsd_host.clone(),
+            statsd_port: metrics.statsd_port,
+            statsd_queue_size: metrics.statsd_queue_size,
+            statsd_buffer_size: metrics.statsd_buffer_size,
+            statsd_prefix: metrics.statsd_prefix,
+        }
+    }
+}
+
+/// The TOML serialization for an [Include](crate::Include) structure.
 #[derive(Serialize, Deserialize)]
 struct Include {
     path: String,
@@ -344,7 +365,7 @@ fn toml_value_to_json(value: toml::Value) -> serde_json::Value {
     }
 }
 
-/// The TOML serialization for a Permissions structure.
+/// The TOML serialization for a [Permissions](crate::Permissions) structure.
 #[derive(Serialize, Deserialize, Clone, Default)]
 struct TomlPermissions {
     #[serde(default)]
@@ -365,7 +386,7 @@ impl From<TomlPermissions> for crate::config::Permissions {
     }
 }
 
-/// The TOML serialization for a Preset structure.
+/// The TOML serialization for a [Preset](crate::Preset) structure.
 #[derive(Validate, Serialize, Deserialize, Clone)]
 struct Preset {
     #[serde(rename(serialize = "ref", deserialize = "ref"))]
@@ -375,7 +396,7 @@ struct Preset {
     plugins: Vec<String>,
 }
 
-/// The TOML serialization for a Resource structure.
+/// The TOML serialization for a [Resource](crate::Resource) structure.
 #[derive(Serialize, Deserialize, Clone)]
 struct Resource {
     route: String,
@@ -519,8 +540,9 @@ where
     let config = crate::Config {
         service: root.service.into(),
         runtime: root.runtime.into(),
-        metrics: root.metrics.into(),
+        state: root.state.into(),
         thresholds: root.thresholds.into(),
+        metrics: root.metrics.into(),
         plugins: root.plugins.iter().map(|plugin| plugin.into()).collect(),
         presets: root
             .presets
@@ -595,14 +617,16 @@ mod tests {
             r#"
         [service]
         port = 10002
+
+        [state]
         redis_uri = "redis://10.0.0.1:6379"
+
+        [thresholds]
+        restrict = 0.75
 
         [metrics]
         statsd_host = "10.0.0.2"
         statsd_prefix = "bulwark_"
-
-        [thresholds]
-        restrict = 0.75
 
         [[include]]
         path = "default.toml"
@@ -625,7 +649,7 @@ mod tests {
         assert_eq!(root.service.port, 10002); // non-default
         assert_eq!(root.service.admin_port, crate::DEFAULT_ADMIN_PORT);
         assert_eq!(
-            root.service.redis_uri,
+            root.state.redis_uri,
             Some(String::from("redis://10.0.0.1:6379"))
         );
 
@@ -676,6 +700,12 @@ mod tests {
 
         assert_eq!(root.service.port, 10002); // non-default
         assert_eq!(root.service.admin_port, crate::DEFAULT_ADMIN_PORT);
+
+        assert_eq!(
+            root.state.redis_uri,
+            Some(String::from("redis://127.0.0.1:6379"))
+        );
+        assert_eq!(root.state.redis_pool_size, crate::DEFAULT_REDIS_POOL_SIZE);
 
         assert_eq!(root.metrics.statsd_host, Some(String::from("10.0.0.2")));
         assert_eq!(root.metrics.statsd_port, Some(8125));

--- a/crates/config/src/toml.rs
+++ b/crates/config/src/toml.rs
@@ -43,10 +43,10 @@ struct Service {
     admin_port: u16,
     #[serde(default = "default_admin")]
     admin_enabled: bool,
-    #[serde(default = "default_remote_state_uri")]
-    remote_state_uri: Option<String>,
-    #[serde(default = "default_remote_state_pool_size")]
-    remote_state_pool_size: u32,
+    #[serde(default = "default_redis_uri")]
+    redis_uri: Option<String>,
+    #[serde(default = "default_redis_pool_size")]
+    redis_pool_size: u32,
     #[serde(default = "default_proxy_hops")]
     proxy_hops: u8,
 }
@@ -71,13 +71,13 @@ fn default_admin() -> bool {
 }
 
 /// The default for the network address to access remote state.
-fn default_remote_state_uri() -> Option<String> {
+fn default_redis_uri() -> Option<String> {
     None
 }
 
 /// The default for the remote state connection pool size.
-fn default_remote_state_pool_size() -> u32 {
-    crate::DEFAULT_REMOTE_STATE_POOL_SIZE
+fn default_redis_pool_size() -> u32 {
+    crate::DEFAULT_REDIS_POOL_SIZE
 }
 
 /// The default number of internal proxy hops expected in front of Bulwark.
@@ -91,8 +91,8 @@ impl Default for Service {
             port: default_port(),
             admin_port: default_admin_port(),
             admin_enabled: default_admin(),
-            remote_state_uri: default_remote_state_uri(),
-            remote_state_pool_size: default_remote_state_pool_size(),
+            redis_uri: default_redis_uri(),
+            redis_pool_size: default_redis_pool_size(),
             proxy_hops: default_proxy_hops(),
         }
     }
@@ -104,8 +104,8 @@ impl From<Service> for crate::Service {
             port: service.port,
             admin_port: service.admin_port,
             admin_enabled: service.admin_enabled,
-            remote_state_uri: service.remote_state_uri.clone(),
-            remote_state_pool_size: service.remote_state_pool_size,
+            redis_uri: service.redis_uri.clone(),
+            redis_pool_size: service.redis_pool_size,
             proxy_hops: service.proxy_hops,
         }
     }
@@ -595,7 +595,7 @@ mod tests {
             r#"
         [service]
         port = 10002
-        remote_state_uri = "redis://10.0.0.1:6379"
+        redis_uri = "redis://10.0.0.1:6379"
 
         [metrics]
         statsd_host = "10.0.0.2"
@@ -625,7 +625,7 @@ mod tests {
         assert_eq!(root.service.port, 10002); // non-default
         assert_eq!(root.service.admin_port, crate::DEFAULT_ADMIN_PORT);
         assert_eq!(
-            root.service.remote_state_uri,
+            root.service.redis_uri,
             Some(String::from("redis://10.0.0.1:6379"))
         );
 

--- a/crates/config/tests/main.toml
+++ b/crates/config/tests/main.toml
@@ -1,6 +1,6 @@
 [service]
 port = 10002
-remote_state_uri = "redis://127.0.0.1:6379"
+redis_uri = "redis://127.0.0.1:6379"
 
 [metrics]
 statsd_host = "10.0.0.2"

--- a/crates/config/tests/main.toml
+++ b/crates/config/tests/main.toml
@@ -1,13 +1,15 @@
 [service]
 port = 10002
+
+[state]
 redis_uri = "redis://127.0.0.1:6379"
+
+[thresholds]
+restrict = 0.75
 
 [metrics]
 statsd_host = "10.0.0.2"
 statsd_prefix = "bulwark_"
-
-[thresholds]
-restrict = 0.75
 
 [[include]]
 path = "include.toml"

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -245,8 +245,8 @@ impl BulwarkProcessor {
         );
         metrics::register_histogram!("combined_decision_score");
 
-        let redis_info = if let Some(redis_addr) = config.service.redis_uri.as_ref() {
-            let pool_size = config.service.redis_pool_size;
+        let redis_info = if let Some(redis_addr) = config.state.redis_uri.as_ref() {
+            let pool_size = config.state.redis_pool_size;
             // TODO: better error handling instead of unwrap/panic
             let client = redis::Client::open(redis_addr.as_str()).unwrap();
             // TODO: make pool size configurable

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -245,10 +245,10 @@ impl BulwarkProcessor {
         );
         metrics::register_histogram!("combined_decision_score");
 
-        let redis_info = if let Some(remote_state_addr) = config.service.remote_state_uri.as_ref() {
-            let pool_size = config.service.remote_state_pool_size;
+        let redis_info = if let Some(redis_addr) = config.service.redis_uri.as_ref() {
+            let pool_size = config.service.redis_pool_size;
             // TODO: better error handling instead of unwrap/panic
-            let client = redis::Client::open(remote_state_addr.as_str()).unwrap();
+            let client = redis::Client::open(redis_addr.as_str()).unwrap();
             // TODO: make pool size configurable
             Some(Arc::new(RedisInfo {
                 // TODO: better error handling instead of unwrap/panic

--- a/crates/wasm-host/src/context.rs
+++ b/crates/wasm-host/src/context.rs
@@ -342,7 +342,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<Option<Vec<u8>>, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -387,7 +387,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<(), crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -436,7 +436,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
                 // Inner function to permit ? operator
                 || -> Result<u32, crate::bindings::bulwark::plugin::redis::Error> {
                     for key in keys.iter() {
-                        verify_remote_state_prefixes(&self.permissions.state, key)?;
+                        verify_redis_prefixes(&self.permissions.state, key)?;
                     }
 
                     if let Some(redis_info) = self.redis_info.clone() {
@@ -507,7 +507,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<i64, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -553,7 +553,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<u32, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -595,7 +595,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<Vec<String>, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -641,7 +641,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<u32, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -684,7 +684,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<(), crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -727,7 +727,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<(), crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info.pool.get().map_err(|err| {
@@ -774,7 +774,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<crate::bindings::bulwark::plugin::redis::Rate, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if delta < 0 {
                         return Err(crate::bindings::bulwark::plugin::redis::Error::InvalidArgument(
@@ -842,7 +842,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
             // Inner function to permit ? operator
             || -> Result<crate::bindings::bulwark::plugin::redis::Rate, crate::bindings::bulwark::plugin::redis::Error> {
-                verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                verify_redis_prefixes(&self.permissions.state, &key)?;
 
                 if let Some(redis_info) = self.redis_info.clone() {
                     let mut conn = redis_info
@@ -901,7 +901,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<crate::bindings::bulwark::plugin::redis::Breaker, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if success_delta < 0 {
                         return Err(crate::bindings::bulwark::plugin::redis::Error::InvalidArgument(
@@ -987,7 +987,7 @@ impl crate::bindings::bulwark::plugin::redis::Host for PluginContext {
             Ok(
                 // Inner function to permit ? operator
                 || -> Result<crate::bindings::bulwark::plugin::redis::Breaker, crate::bindings::bulwark::plugin::redis::Error> {
-                    verify_remote_state_prefixes(&self.permissions.state, &key)?;
+                    verify_redis_prefixes(&self.permissions.state, &key)?;
 
                     if let Some(redis_info) = self.redis_info.clone() {
                         let mut conn = redis_info
@@ -1051,7 +1051,7 @@ fn verify_http_domains(
 }
 
 /// Ensures that access to any remote state key has the appropriate permissions set.
-fn verify_remote_state_prefixes(
+fn verify_redis_prefixes(
     // TODO: BTreeSet<String> instead, all the way up
     allowed_key_prefixes: &[String],
     key: &str,

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -330,7 +330,6 @@ impl EcsFormatter {
                     let unquoted_tags = quoted_string::to_content::<TraceQuoteSpec>(field.value())
                         .map_err(|_| fmt::Error)?;
                     let tags: Vec<String> = unquoted_tags
-                        .to_string()
                         .split(',')
                         .map(|s| s.trim().to_ascii_lowercase())
                         .filter(|s| !s.is_empty())

--- a/tests/exec_plugin.rs
+++ b/tests/exec_plugin.rs
@@ -19,8 +19,9 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),
             runtime: bulwark_config::Runtime::default(),
-            metrics: bulwark_config::Metrics::default(),
+            state: bulwark_config::State::default(),
             thresholds: bulwark_config::Thresholds::default(),
+            metrics: bulwark_config::Metrics::default(),
             plugins: vec![],
             presets: vec![],
             resources: vec![],
@@ -109,8 +110,9 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),
             runtime: bulwark_config::Runtime::default(),
-            metrics: bulwark_config::Metrics::default(),
+            state: bulwark_config::State::default(),
             thresholds: bulwark_config::Thresholds::default(),
+            metrics: bulwark_config::Metrics::default(),
             plugins: vec![],
             presets: vec![],
             resources: vec![],
@@ -198,8 +200,9 @@ fn test_evil_bit_evil_exec() -> Result<(), Box<dyn std::error::Error>> {
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),
             runtime: bulwark_config::Runtime::default(),
-            metrics: bulwark_config::Metrics::default(),
+            state: bulwark_config::State::default(),
             thresholds: bulwark_config::Thresholds::default(),
+            metrics: bulwark_config::Metrics::default(),
             plugins: vec![],
             presets: vec![],
             resources: vec![],


### PR DESCRIPTION
In line with the previous changes to the API, this updates everywhere else in the codebase that referenced "remote state" instead of just simply saying "Redis". The previous abstraction wasn't beneficial and I think it's always useful to be aware of an important implementation detail like Redis being in use, so this stops hiding it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Renamed configuration parameters to more accurately reflect their purpose related to Redis integration.
- **Tests**
	- Updated test functions in `exec_plugin.rs` to align with changes in the `bulwark_config::Config` struct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->