### PR TITLE
Add a dependency check for licenses and vulnerabilities

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,4 +1,4 @@
-name: 'Dependency Review'
+name: 'Dependency Checks'
 on: [pull_request]
 
 permissions:
@@ -9,10 +9,20 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
-        with:
-            comment-summary-in-pr: on-failure
-            deny-licenses: MS-LPL, BUSL-1.1, QPL-1.0, Sleepycat, SSPL-1.0, CPOL-1.02, AGPL-1.0-or-later, GPL-1.0-or-later, BSD-4-Clause-UC, NPOSL-3.0, NPL-1.1, JSON
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v4
+    - name: 'Dependency Review'
+      uses: actions/dependency-review-action@v4
+      with:
+        comment-summary-in-pr: on-failure
+        deny-licenses: MS-LPL, BUSL-1.1, QPL-1.0, Sleepycat, SSPL-1.0, CPOL-1.02, AGPL-1.0-or-later, GPL-1.0-or-later, BSD-4-Clause-UC, NPOSL-3.0, NPL-1.1, JSON
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: 'cargo deny'
+      uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check
+        command-arguments: licenses

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,18 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+            comment-summary-in-pr: on-failure
+            deny-licenses: MS-LPL, BUSL-1.1, QPL-1.0, Sleepycat, SSPL-1.0, CPOL-1.02, AGPL-1.0-or-later, GPL-1.0-or-later, BSD-4-Clause-UC, NPOSL-3.0, NPL-1.1, JSON

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+]
+exceptions = [
+    { allow = [
+        "Unicode-DFS-2016",
+    ], crate = "unicode-ident" },
+    { allow = [
+        "OpenSSL",
+    ], crate = "ring" },
+]
+
+[[licenses.clarify]]
+crate = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]


### PR DESCRIPTION
This is currently more for the license check since we have vulnerability scanning via GitHub already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Implemented a GitHub Actions workflow named 'Dependency Checks' triggered on pull requests to review dependencies for specific licenses.
    - Added a summary comment in the pull request in case of dependency failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->