### PR TITLE
Uninitialized values are now explicitly handled for rate limiters and breakers

### DIFF
--- a/crates/wasm-sdk/src/redis.rs
+++ b/crates/wasm-sdk/src/redis.rs
@@ -265,7 +265,7 @@ pub fn incr_rate_limit<K: AsRef<str>>(
 /// # Arguments
 ///
 /// * `key` - The key name corresponding to the state counter.
-pub fn check_rate_limit<K: AsRef<str>>(key: K) -> Result<Rate, crate::RemoteStateError> {
+pub fn check_rate_limit<K: AsRef<str>>(key: K) -> Result<Option<Rate>, crate::RemoteStateError> {
     let key: &str = key.as_ref();
     Ok(crate::wit::bulwark::plugin::redis::check_rate_limit(key)?)
 }
@@ -344,7 +344,7 @@ pub fn incr_breaker<K: AsRef<str>>(
 ///
 /// * `key` - The key name corresponding to the state counter.
 #[inline]
-pub fn check_breaker<K: AsRef<str>>(key: K) -> Result<Breaker, crate::RemoteStateError> {
+pub fn check_breaker<K: AsRef<str>>(key: K) -> Result<Option<Breaker>, crate::RemoteStateError> {
     let key: &str = key.as_ref();
     Ok(crate::wit::bulwark::plugin::redis::check_breaker(key)?)
 }

--- a/tests/exec_plugin.rs
+++ b/tests/exec_plugin.rs
@@ -7,14 +7,14 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
 
     bulwark_build::build_plugin(
         base.join("../crates/wasm-sdk/examples/blank-slate"),
-        base.join("dist/plugins/blank-slate.wasm"),
+        base.join("dist/plugins/bulwark_blank_slate.wasm"),
         &[],
         true,
     )?;
-    assert!(base.join("dist/plugins/blank-slate.wasm").exists());
+    assert!(base.join("dist/plugins/bulwark_blank_slate.wasm").exists());
 
     let plugin = Arc::new(Plugin::from_file(
-        base.join("dist/plugins/blank-slate.wasm"),
+        base.join("dist/plugins/bulwark_blank_slate.wasm"),
         // None of this config will get read during this test.
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),
@@ -102,14 +102,14 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
 
     bulwark_build::build_plugin(
         base.join("../crates/wasm-sdk/examples/evil-bit"),
-        base.join("dist/plugins/evil-bit.wasm"),
+        base.join("dist/plugins/bulwark_evil_bit.wasm"),
         &[],
         true,
     )?;
-    assert!(base.join("dist/plugins/evil-bit.wasm").exists());
+    assert!(base.join("dist/plugins/bulwark_evil_bit.wasm").exists());
 
     let plugin = Arc::new(Plugin::from_file(
-        base.join("dist/plugins/evil-bit.wasm"),
+        base.join("dist/plugins/bulwark_evil_bit.wasm"),
         // None of this config will get read during this test.
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),

--- a/wit/redis.wit
+++ b/wit/redis.wit
@@ -84,11 +84,11 @@ interface redis {
     /// Increments a rate limit, returning the number of attempts so far and the expiration time.
     incr-rate-limit: func(key: string, delta: s64, window: s64) -> result<rate, error>;
     /// Checks a rate limit, returning the number of attempts so far and the expiration time.
-    check-rate-limit: func(key: string) -> result<rate, error>;
+    check-rate-limit: func(key: string) -> result<option<rate>, error>;
     /// Increments a circuit breaker, returning the generation count, success count, failure count,
     /// consecutive success count, consecutive failure count, and expiration time.
     incr-breaker: func(key: string, success-delta: s64, failure-delta: s64, window: s64) -> result<breaker, error>;
     /// Checks a circuit breaker, returning the generation count, success count, failure count,
     /// consecutive success count, consecutive failure count, and expiration time.
-    check-breaker: func(key: string) -> result<breaker, error>;
+    check-breaker: func(key: string) -> result<option<breaker>, error>;
 }


### PR DESCRIPTION
Previously, calling `check_rate_limit` or `check_breaker` on a key that hadn't been incremented prior would give this error:

```
Error::Remote("Response was of incompatible type - TypeError: \"Bulk response of wrong dimension\" (response was bulk())"))
```

The entire scenario wasn't handled well in the code, but this specific error message was triggered by the Lua scripts returning `nil` for missing values when the Rust code expected to only ever get an `i64` back. The scripts have been updated to return 0 instead. A 0 value can only happen if the value is uninitialized so the Rust code now turns this back into an `Option` with a `None` value if it encounters a 0.

Also adds tests for all the other Redis API calls we support to verify behavior for uninitialized values. These all worked as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified logic for handling attempts and expiration in Redis operations.
- **New Features**
	- Enhanced error handling and assertions for Redis operations in tests.
- **Tests**
	- Updated file paths for generated wasm files in tests.
- **Documentation**
	- Updated the `redis` interface to reflect changes in return types for rate limit and circuit breaker checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->