### PR TITLE
Need to expose HeaderValue

### DIFF
--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -24,6 +24,8 @@ pub type Response = http::Response<Bytes>;
 pub type ResponseBuilder = http::response::Builder;
 /// An HTTP uri builder type alias. See [`http::uri::Builder`] for details.
 pub type UriBuilder = http::uri::Builder;
+/// An HTTP header value type alias. See [`http::HeaderValue`] for details.
+pub type HeaderValue = http::HeaderValue;
 
 // TODO: perhaps something more like http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>?
 // TODO: or hyper::Request<HyperIncomingBody> to match WasiHttpView's new_incoming_request?


### PR DESCRIPTION
We do not want to require plugins to explicitly depend on the `http` crate themselves. This is most relevant when a plugin needs to operate on a `&HeaderValue` parameter in a function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Introduced a new type alias for HTTP header values to enhance code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->