### PR TITLE
Rename params to labels

### DIFF
--- a/crates/wasm-host/src/from.rs
+++ b/crates/wasm-host/src/from.rs
@@ -144,7 +144,7 @@ impl From<crate::bindings::bulwark::plugin::types::HandlerOutput> for HandlerOut
         Self {
             decision: output.decision.into(),
             tags: HashSet::from_iter(output.tags),
-            params: HashMap::from_iter(output.params),
+            labels: HashMap::from_iter(output.labels),
         }
     }
 }

--- a/crates/wasm-sdk-macros/src/lib.rs
+++ b/crates/wasm-sdk-macros/src/lib.rs
@@ -15,15 +15,9 @@ const WIT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/wit");
 /// processing will continue to the next handler.
 ///
 /// # Trait Functions
-/// - `handle_init` - Not typically used. Called when the plugin is first loaded. If defined, overrides the
-///   default macro behavior of calling
-///   [`receive_request_body(true)`](https://docs.rs/bulwark-wasm-sdk/latest/bulwark_wasm_sdk/fn.receive_request_body.html)
-///   or [`receive_response_body(true)`](https://docs.rs/bulwark-wasm-sdk/latest/bulwark_wasm_sdk/fn.receive_response_body.html)
-///   when the corresponding handlers have been defined.
+/// - `handle_init` - Rarely used. Called when the plugin is first loaded.
 /// - `handle_request_enrichment` - This handler is called for every incoming request, before any decision-making will occur.
-///   It is typically used to perform enrichment tasks with the
-///   [`set_param_value`](https://docs.rs/bulwark-wasm-sdk/latest/bulwark_wasm_sdk/fn.set_param_value.html) function.
-///   The request body will not yet be available when this handler is called.
+///   It is typically used to perform enrichment tasks.
 /// - `handle_request_decision` - This handler is called to make an initial decision.
 /// - `handle_response_decision` - This handler is called once the interior service has received the request, processed it, and
 ///   returned a response, but prior to that response being sent onwards to the original exterior client. Notably, a `restricted`
@@ -44,7 +38,10 @@ const WIT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/wit");
 ///
 /// #[bulwark_plugin]
 /// impl Handlers for ExamplePlugin {
-///     fn handle_request_decision() -> Result {
+///     fn handle_request_decision(
+///         req: Request,
+///         labels: HashMap<String, String>,
+///     ) -> Result {
 ///         println!("hello world");
 ///         // implement detection logic here
 ///         Ok(())
@@ -159,7 +156,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
                             _: ::std::collections::HashMap<String, String>
                         ) -> Result<::bulwark_wasm_sdk::HandlerOutput, ::bulwark_wasm_sdk::Error> {
                             Ok(::bulwark_wasm_sdk::HandlerOutput {
-                                params: ::std::collections::HashMap::new(),
+                                labels: ::std::collections::HashMap::new(),
                                 decision: ::bulwark_wasm_sdk::Decision::default(),
                                 tags: vec![],
                             })
@@ -175,7 +172,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
                             _: ::std::collections::HashMap<String, String>
                         ) -> Result<::bulwark_wasm_sdk::HandlerOutput, ::bulwark_wasm_sdk::Error> {
                             Ok(::bulwark_wasm_sdk::HandlerOutput {
-                                params: ::std::collections::HashMap::new(),
+                                labels: ::std::collections::HashMap::new(),
                                 decision: ::bulwark_wasm_sdk::Decision::default(),
                                 tags: vec![],
                             })
@@ -243,7 +240,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
         impl From<crate::handlers::exports::bulwark::plugin::http_handlers::HandlerOutput> for ::bulwark_wasm_sdk::HandlerOutput {
             fn from(handler_output: crate::handlers::exports::bulwark::plugin::http_handlers::HandlerOutput) -> Self {
                 Self {
-                    params: handler_output.params.iter().cloned().collect(),
+                    labels: handler_output.labels.iter().cloned().collect(),
                     decision: handler_output.decision.into(),
                     tags: handler_output.tags.clone(),
                 }
@@ -253,7 +250,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
         impl From<bulwark_wasm_sdk::HandlerOutput> for crate::handlers::exports::bulwark::plugin::http_handlers::HandlerOutput {
             fn from(handler_output: ::bulwark_wasm_sdk::HandlerOutput) -> Self {
                 Self {
-                    params: handler_output.params.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                    labels: handler_output.labels.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
                     decision: handler_output.decision.into(),
                     tags: handler_output.tags.clone(),
                 }
@@ -430,8 +427,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
 /// The `handler` attribute is normally applied automatically by the `bulwark_plugin` macro and
 /// need not be specified explicitly.
 ///
-/// The associated function must take no parameters and return a `bulwark_wasm_sdk::Result`. It may only be
-/// named one of the following:
+/// The associated function must have the correct signature and may only be named one of the following:
 /// - `handle_init`
 /// - `handle_request_enrichment`
 /// - `handle_request_decision`
@@ -479,16 +475,16 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                 #(#attrs)*
                 fn handle_request_enrichment(
                     request: handlers::wasi::http::types::IncomingRequest,
-                    params: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Param>,
+                    labels: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Label>,
                 ) -> Result<
-                    wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Param>,
+                    wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Label>,
                     handlers::exports::bulwark::plugin::http_handlers::Error,
                 > {
                     // Declares the inlined inner function, calls it, then performs very
                     // basic error handling on the result
                     #[inline(always)]
                     #inner_fn
-                    let result = #name(request.try_into()?, params.iter().cloned().collect()).map(|t| {
+                    let result = #name(request.try_into()?, labels.iter().cloned().collect()).map(|t| {
                         t.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
                     }).map_err(|e| {
                         handlers::exports::bulwark::plugin::http_handlers::Error::Other(e.to_string())
@@ -510,7 +506,7 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                 #(#attrs)*
                 fn handle_request_decision(
                     request: handlers::wasi::http::types::IncomingRequest,
-                    params: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Param>,
+                    labels: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Label>,
                 ) -> Result<
                     handlers::exports::bulwark::plugin::http_handlers::HandlerOutput,
                     handlers::exports::bulwark::plugin::http_handlers::Error,
@@ -518,7 +514,7 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                     // Declares the inlined inner function, calls it, then translates the result
                     #[inline(always)]
                     #inner_fn
-                    let result = #name(request.try_into()?, params.iter().cloned().collect()).map(|t| {
+                    let result = #name(request.try_into()?, labels.iter().cloned().collect()).map(|t| {
                         t.into()
                     }).map_err(|e| {
                         handlers::exports::bulwark::plugin::http_handlers::Error::Other(e.to_string())
@@ -541,7 +537,7 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                 fn handle_response_decision(
                     request: handlers::wasi::http::types::IncomingRequest,
                     response: handlers::wasi::http::types::IncomingResponse,
-                    params: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Param>,
+                    labels: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Label>,
                 ) -> Result<
                     handlers::exports::bulwark::plugin::http_handlers::HandlerOutput,
                     handlers::exports::bulwark::plugin::http_handlers::Error,
@@ -550,7 +546,7 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                     // basic error handling on the result
                     #[inline(always)]
                     #inner_fn
-                    let result = #name(request.try_into()?, response.try_into()?, params.iter().cloned().collect()).map(|t| {
+                    let result = #name(request.try_into()?, response.try_into()?, labels.iter().cloned().collect()).map(|t| {
                         t.into()
                     }).map_err(|e| {
                         handlers::exports::bulwark::plugin::http_handlers::Error::Other(e.to_string())
@@ -573,14 +569,14 @@ pub fn handler(_: TokenStream, input: TokenStream) -> TokenStream {
                 fn handle_decision_feedback(
                     request: handlers::wasi::http::types::IncomingRequest,
                     response: handlers::wasi::http::types::IncomingResponse,
-                    params: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Param>,
+                    labels: wit_bindgen::rt::vec::Vec<handlers::bulwark::plugin::types::Label>,
                     verdict: handlers::bulwark::plugin::types::Verdict,
                 ) -> Result<(), handlers::exports::bulwark::plugin::http_handlers::Error> {
                     // Declares the inlined inner function, calls it, then performs very
                     // basic error handling on the result
                     #[inline(always)]
                     #inner_fn
-                    let result = #name(request.try_into()?, response.try_into()?, params.iter().cloned().collect(), verdict.into()).map_err(|e| {
+                    let result = #name(request.try_into()?, response.try_into()?, labels.iter().cloned().collect(), verdict.into()).map_err(|e| {
                         handlers::exports::bulwark::plugin::http_handlers::Error::Other(e.to_string())
                     });
                     #[allow(unused_must_use)]

--- a/crates/wasm-sdk/examples/blank-slate/src/lib.rs
+++ b/crates/wasm-sdk/examples/blank-slate/src/lib.rs
@@ -7,7 +7,7 @@ pub struct BlankSlate;
 impl HttpHandlers for BlankSlate {
     fn handle_request_enrichment(
         _request: Request,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Error> {
         // Cross-plugin communication logic goes here, or leave as a no-op.
         Ok(HashMap::new())
@@ -15,7 +15,7 @@ impl HttpHandlers for BlankSlate {
 
     fn handle_request_decision(
         _request: Request,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
     ) -> Result<HandlerOutput, Error> {
         let mut output = HandlerOutput::default();
         // Main detection logic goes here.
@@ -27,7 +27,7 @@ impl HttpHandlers for BlankSlate {
     fn handle_response_decision(
         _request: Request,
         _response: Response,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
     ) -> Result<HandlerOutput, Error> {
         let mut output = HandlerOutput::default();
         // Process responses from the interior service here, or leave as a no-op.
@@ -38,7 +38,7 @@ impl HttpHandlers for BlankSlate {
     fn handle_decision_feedback(
         _request: Request,
         _response: Response,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
         _verdict: Verdict,
     ) -> Result<(), Error> {
         // Feedback loop implementations go here, or leave as a no-op.

--- a/crates/wasm-sdk/examples/evil-bit/src/lib.rs
+++ b/crates/wasm-sdk/examples/evil-bit/src/lib.rs
@@ -8,7 +8,7 @@ impl HttpHandlers for EvilBit {
     /// Check to see if the request has confessed malicious intent by setting an `Evil` header.
     fn handle_request_decision(
         request: Request,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
     ) -> Result<HandlerOutput, Error> {
         let mut output = HandlerOutput::default();
         let evil_header = request.headers().get("Evil");

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -71,8 +71,8 @@ pub type HeaderValue = http::HeaderValue;
 /// A `HandlerOutput` represents a decision and associated output for a single handler within a single detection.
 #[derive(Clone, Default)]
 pub struct HandlerOutput {
-    /// The `params` value represents the new params to enrich the request with.
-    pub params: HashMap<String, String>,
+    /// The `labels` field contains key/value pairs used to enrich the request with additional information.
+    pub labels: HashMap<String, String>,
     /// The `decision` value represents the combined numerical decision from multiple detections.
     pub decision: Decision,
     /// The `tags` value represents the new tags to annotate the request with.

--- a/tests/exec_plugin.rs
+++ b/tests/exec_plugin.rs
@@ -46,14 +46,14 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_init())?;
 
     // Perform request enrichment.
-    let new_params = tokio_test::block_on(
+    let new_labels = tokio_test::block_on(
         plugin_instance.handle_request_enrichment(request.clone(), HashMap::new()),
     )?;
-    assert!(new_params.is_empty());
+    assert!(new_labels.is_empty());
 
     // Handle request decision.
     let handler_output =
-        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_params))?;
+        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_labels))?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
     assert_eq!(handler_output.decision.restrict, 0.0);
@@ -72,7 +72,7 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
     let handler_output = tokio_test::block_on(plugin_instance.handle_response_decision(
         request.clone(),
         response.clone(),
-        handler_output.params,
+        handler_output.labels,
     ))?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
@@ -85,7 +85,7 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_decision_feedback(
         request.clone(),
         response.clone(),
-        handler_output.params,
+        handler_output.labels,
         bulwark_wasm_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_wasm_sdk::Outcome::Accepted,
@@ -141,14 +141,14 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_init())?;
 
     // Perform request enrichment.
-    let new_params = tokio_test::block_on(
+    let new_labels = tokio_test::block_on(
         plugin_instance.handle_request_enrichment(request.clone(), HashMap::new()),
     )?;
-    assert!(new_params.is_empty());
+    assert!(new_labels.is_empty());
 
     // Handle request decision.
     let handler_output =
-        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_params))?;
+        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_labels))?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
     assert_eq!(handler_output.decision.restrict, 0.0);
@@ -167,7 +167,7 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
     let handler_output = tokio_test::block_on(plugin_instance.handle_response_decision(
         request.clone(),
         response.clone(),
-        handler_output.params,
+        handler_output.labels,
     ))?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
@@ -179,7 +179,7 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_decision_feedback(
         request.clone(),
         response.clone(),
-        handler_output.params,
+        handler_output.labels,
         bulwark_wasm_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_wasm_sdk::Outcome::Accepted,
@@ -237,14 +237,14 @@ fn test_evil_bit_evil_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_init())?;
 
     // Perform request enrichment.
-    let new_params = tokio_test::block_on(
+    let new_labels = tokio_test::block_on(
         plugin_instance.handle_request_enrichment(request.clone(), HashMap::new()),
     )?;
-    assert!(new_params.is_empty());
+    assert!(new_labels.is_empty());
 
     // Handle request decision.
     let handler_output =
-        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_params))?;
+        tokio_test::block_on(plugin_instance.handle_request_decision(request.clone(), new_labels))?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
     assert_eq!(handler_output.decision.restrict, 1.0);
@@ -264,7 +264,7 @@ fn test_evil_bit_evil_exec() -> Result<(), Box<dyn std::error::Error>> {
     tokio_test::block_on(plugin_instance.handle_decision_feedback(
         request.clone(),
         response.clone(),
-        handler_output.params,
+        handler_output.labels,
         bulwark_wasm_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_wasm_sdk::Outcome::Restricted,

--- a/tests/plugins/redis-plugin/src/lib.rs
+++ b/tests/plugins/redis-plugin/src/lib.rs
@@ -25,7 +25,7 @@ impl HttpHandlers for RedisPlugin {
 
     fn handle_request_decision(
         _request: Request,
-        _params: HashMap<String, String>,
+        _labels: HashMap<String, String>,
     ) -> Result<HandlerOutput, Error> {
         let mut output = HandlerOutput::default();
 

--- a/tests/redis.rs
+++ b/tests/redis.rs
@@ -82,14 +82,14 @@ async fn test_redis_plugin() -> Result<(), Box<dyn std::error::Error>> {
     plugin_instance.handle_init().await?;
 
     // Perform request enrichment.
-    let new_params = plugin_instance
+    let new_labels = plugin_instance
         .handle_request_enrichment(request.clone(), HashMap::new())
         .await?;
-    assert!(new_params.is_empty());
+    assert!(new_labels.is_empty());
 
     // Handle request decision.
     let handler_output = plugin_instance
-        .handle_request_decision(request.clone(), new_params)
+        .handle_request_decision(request.clone(), new_labels)
         .await?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
@@ -107,7 +107,7 @@ async fn test_redis_plugin() -> Result<(), Box<dyn std::error::Error>> {
 
     // Handle response decision.
     let handler_output = plugin_instance
-        .handle_response_decision(request.clone(), response.clone(), handler_output.params)
+        .handle_response_decision(request.clone(), response.clone(), handler_output.labels)
         .await?;
 
     assert_eq!(handler_output.decision.accept, 0.0);
@@ -121,7 +121,7 @@ async fn test_redis_plugin() -> Result<(), Box<dyn std::error::Error>> {
         .handle_decision_feedback(
             request.clone(),
             response.clone(),
-            handler_output.params,
+            handler_output.labels,
             bulwark_wasm_sdk::Verdict {
                 decision: handler_output.decision,
                 outcome: bulwark_wasm_sdk::Outcome::Accepted,

--- a/wit/handlers.wit
+++ b/wit/handlers.wit
@@ -2,25 +2,25 @@ use wasi:http/types@0.2.0 as http-types;
 
 interface http-handlers {
     use http-types.{incoming-request, incoming-response};
-    use types.{handler-output, decision, outcome, param, verdict};
+    use types.{handler-output, decision, outcome, label, verdict};
 
     /// Called once when the plugin is first instantiated.
     handle-init: func() -> result<_, error>;
     /// Called on every request.
     ///
     /// Plugins should use this handler to perform request enrichment
-    /// by adding new parameters to the handler output. Plugins should not
-    /// copy input params into output params as the host will automatically
+    /// by adding new labels to the handler output. Plugins should not
+    /// copy input labels into output labels as the host will automatically
     /// merge these. Copying may create conflict resolution issues.
     ///
     /// This is the first handler to execute in response to a request and
-    /// any params it emits are guaranteed to be available to all other
+    /// any labels it emits are guaranteed to be available to all other
     /// plugins prior to their decision handlers being called.
-    handle-request-enrichment: func(request: incoming-request, params: list<param>) -> result<list<param>, error>;
+    handle-request-enrichment: func(request: incoming-request, labels: list<label>) -> result<list<label>, error>;
     /// Generates the initial verdict by the plugin, prior to sending the request to the interior service.
     ///
     /// Most plugin decision logic should take place in this handler.
-    handle-request-decision: func(request: incoming-request, params: list<param>) -> result<handler-output, error>;
+    handle-request-decision: func(request: incoming-request, labels: list<label>) -> result<handler-output, error>;
     /// Generates a secondary verdict after the interior service has sent back its response.
     ///
     /// Plugins that need to inspect responses, particularly response
@@ -28,14 +28,14 @@ interface http-handlers {
     /// any side effects from the request on the interior service will
     /// have already taken place, so any blocking logic that results from
     /// a decision by the plugin in this handler is no longer preventative.
-    handle-response-decision: func(request: incoming-request, response: incoming-response, params: list<param>) -> result<handler-output, error>;
+    handle-response-decision: func(request: incoming-request, response: incoming-response, labels: list<label>) -> result<handler-output, error>;
     /// Called after all plugins have rendered their decisions and the results combined.
     ///
     /// This handler may be used to create feedback loops, train models, or to make API calls
     /// to internal services (e.g. session termination). Notably, session termination or other
     /// mitigation steps may be particularly relevant if a blocking operation happened in the
     /// response handler rather than the request handler.
-    handle-decision-feedback: func(request: incoming-request, response: incoming-response, params: list<param>, verdict: verdict) -> result<_, error>;
+    handle-decision-feedback: func(request: incoming-request, response: incoming-response, labels: list<label>, verdict: verdict) -> result<_, error>;
 
     // TODO: the handler error should be easy to use with the ? operator.
 

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -37,8 +37,8 @@ interface types {
 
     /// A `HandlerOutput` represents the combined result of executing a detection's handlers.
     record handler-output {
-        /// The `params` value represents parameters used to enrich the request with additional information.
-        params: list<param>,
+        /// The `labels` field contains key/value pairs used to enrich the request with additional information.
+        labels: list<label>,
         /// The `decision` value represents the verdict of the handler.
         decision: decision,
         /// The `tags` value represents tags used to annotate the request.
@@ -55,9 +55,9 @@ interface types {
         tags: list<string>,
     }
 
-    /// A `Param` maps a parameter name to a parameter value.
+    /// A `Label` maps a label name to a label value.
     ///
-    /// Parameters are used to represent arbitrary information about a request. They may be application-specific and are
+    /// Labels are used to represent arbitrary information about a request. They may be application-specific and are
     /// often produced by parsing the request, decrypting session cookies, or by calling out to an external service.
-    type param = tuple<string, string>;
+    type label = tuple<string, string>;
 }


### PR DESCRIPTION
Closes #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed variables from `params` to `labels` across various files for clarity and consistency.
	- Updated function calls, assignments, and struct fields to reflect the renaming.
	- Improved logging messages and error handling.

- **Documentation**
	- Streamlined descriptions and adjusted parameter names in documentation to match the new naming convention.

- **Tests**
	- Updated test cases to use `labels` instead of `params`, maintaining logic and control flow.

- **Chores**
	- Altered interface parameter names from `params` to `labels` for consistency in plugin logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->