### PR TITLE
Reexport 'http' crate instead of aliasing the things we need individually

### DIFF
--- a/crates/wasm-sdk-macros/src/lib.rs
+++ b/crates/wasm-sdk-macros/src/lib.rs
@@ -283,10 +283,10 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
 
             fn try_from(request: crate::handlers::wasi::http::types::IncomingRequest) -> Result<Self, Self::Error> {
                 const MAX_SIZE: u64 = 1048576;
-                let mut builder = ::bulwark_wasm_sdk::RequestBuilder::new();
+                let mut builder = ::bulwark_wasm_sdk::http::request::Builder::new();
                 // Builder doesn't support scheme or authority as separate functions,
                 // so we need to manually construct the URI.
-                let mut uri = ::bulwark_wasm_sdk::UriBuilder::new();
+                let mut uri = ::bulwark_wasm_sdk::http::uri::Builder::new();
                 if let Some(scheme) = request.scheme() {
                     let other;
                     uri = uri.scheme(match scheme {
@@ -368,7 +368,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
 
             fn try_from(response: crate::handlers::wasi::http::types::IncomingResponse) -> Result<Self, Self::Error> {
                 const MAX_SIZE: u64 = 1048576;
-                let mut builder = ::bulwark_wasm_sdk::ResponseBuilder::new();
+                let mut builder = ::bulwark_wasm_sdk::http::response::Builder::new();
                 // We have no way to know the HTTP version here, so leave it as default.
                 builder = builder.status(response.status());
 

--- a/crates/wasm-sdk/src/host_api.rs
+++ b/crates/wasm-sdk/src/host_api.rs
@@ -15,17 +15,11 @@ pub type Bytes = bytes::Bytes;
 /// An HTTP request combines a head consisting of a [`Method`], [`Uri`], and headers with a [`BodyChunk`], which provides
 /// access to the first chunk of a request body.
 pub type Request = http::Request<Bytes>;
-/// An HTTP request builder type alias. See [`http::request::Builder`] for details.
-pub type RequestBuilder = http::request::Builder;
 /// An HTTP response combines a head consisting of a [`StatusCode`] and headers with a [`BodyChunk`], which provides
 /// access to the first chunk of a response body.
 pub type Response = http::Response<Bytes>;
-/// An HTTP response builder type alias. See [`http::response::Builder`] for details.
-pub type ResponseBuilder = http::response::Builder;
-/// An HTTP uri builder type alias. See [`http::uri::Builder`] for details.
-pub type UriBuilder = http::uri::Builder;
-/// An HTTP header value type alias. See [`http::HeaderValue`] for details.
-pub type HeaderValue = http::HeaderValue;
+/// Reexports the `http` crate.
+pub use http;
 
 // TODO: perhaps something more like http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>?
 // TODO: or hyper::Request<HyperIncomingBody> to match WasiHttpView's new_incoming_request?


### PR DESCRIPTION
Closes #218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the plugin function to use new HTTP request and response builders for improved efficiency and organization.
- **Chores**
	- Removed outdated type aliases and implemented direct usage of the `http` crate for clearer and more direct code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->