### PR TITLE
Fix missing handler output issue on panic

### DIFF
--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -867,8 +867,15 @@ impl ProcessorContext {
                 let decision = self
                     .plugin_outputs
                     .get(&plugin_instance.plugin_reference())
-                    .expect("missing plugin output")
-                    .decision;
+                    .map(|output| output.decision)
+                    // This could happen if the plugin panics.
+                    .unwrap_or_else(|| {
+                        warn!(
+                            message = "plugin decision missing",
+                            reference = &plugin_instance.plugin_reference(),
+                        );
+                        Decision::default()
+                    });
                 metrics::histogram!(
                     "decision_score",
                     decision.pignistic().restrict,


### PR DESCRIPTION
Closes #215.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling for missing plugin output to improve resilience and robustness, including logging a warning for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->