### PR TITLE
Format f64 w/ 3 decimal places

### DIFF
--- a/crates/ext-processor/src/format.rs
+++ b/crates/ext-processor/src/format.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Float3Formatter(pub f64);
+
+impl std::fmt::Display for Float3Formatter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(format!("{:.3}", self.0).as_str())?;
+
+        Ok(())
+    }
+}

--- a/crates/ext-processor/src/format.rs
+++ b/crates/ext-processor/src/format.rs
@@ -3,7 +3,7 @@ pub(crate) struct Float3Formatter(pub f64);
 
 impl std::fmt::Display for Float3Formatter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(format!("{:.3}", self.0).as_str())?;
+        write!(f, "{:.3}", self.0)?;
 
         Ok(())
     }

--- a/crates/ext-processor/src/lib.rs
+++ b/crates/ext-processor/src/lib.rs
@@ -3,6 +3,7 @@
 //! [1]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter
 
 mod errors;
+mod format;
 mod service;
 
 pub use errors::*;

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -37,6 +37,12 @@ use tokio::{sync::RwLock, sync::Semaphore, task::JoinSet, time::timeout};
 use tonic::Streaming;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument};
 
+macro_rules! format_f64 {
+    ($expression:expr) => {
+        tracing::field::display(crate::format::Float3Formatter($expression))
+    };
+}
+
 extern crate redis;
 
 type ExternalProcessorStream =
@@ -674,11 +680,11 @@ impl ProcessorContext {
                         info!(
                             message = "plugin decision",
                             name = plugin_instance.plugin_reference(),
-                            accept = decision.accept,
-                            restrict = decision.restrict,
-                            unknown = decision.unknown,
-                            score = decision.pignistic().restrict,
-                            weight = plugin_instance.weight(),
+                            accept = format_f64!(decision.accept),
+                            restrict = format_f64!(decision.restrict),
+                            unknown = format_f64!(decision.unknown),
+                            score = format_f64!(decision.pignistic().restrict),
+                            weight = format_f64!(plugin_instance.weight()),
                         );
 
                         let mut outputs = outputs.lock().await;
@@ -774,11 +780,11 @@ impl ProcessorContext {
                         info!(
                             message = "plugin decision",
                             name = plugin_instance.plugin_reference(),
-                            accept = decision.accept,
-                            restrict = decision.restrict,
-                            unknown = decision.unknown,
-                            score = decision.pignistic().restrict,
-                            weight = plugin_instance.weight(),
+                            accept = format_f64!(decision.accept),
+                            restrict = format_f64!(decision.restrict),
+                            unknown = format_f64!(decision.unknown),
+                            score = format_f64!(decision.pignistic().restrict),
+                            weight = format_f64!(plugin_instance.weight()),
                         );
 
                         if let Some(prior_plugin_outputs) = prior_plugin_outputs {
@@ -933,10 +939,10 @@ impl ProcessorContext {
 
         info!(
             message = "combine decision",
-            accept = decision.accept,
-            restrict = decision.restrict,
-            unknown = decision.unknown,
-            score = decision.pignistic().restrict,
+            accept = format_f64!(decision.accept),
+            restrict = format_f64!(decision.restrict),
+            unknown = format_f64!(decision.unknown),
+            score = format_f64!(decision.pignistic().restrict),
             outcome = outcome.to_string(),
             observe_only = self.thresholds.observe_only,
             // array values aren't handled well unfortunately, coercing to comma-separated values seems to be the best option
@@ -1052,10 +1058,10 @@ impl ProcessorContext {
 
         info!(
             message = "combine decision",
-            accept = decision.accept,
-            restrict = decision.restrict,
-            unknown = decision.unknown,
-            score = decision.pignistic().restrict,
+            accept = format_f64!(decision.accept),
+            restrict = format_f64!(decision.restrict),
+            unknown = format_f64!(decision.unknown),
+            score = format_f64!(decision.pignistic().restrict),
             outcome = outcome.to_string(),
             observe_only = self.thresholds.observe_only,
             // array values aren't handled well unfortunately, coercing to comma-separated values seems to be the best option


### PR DESCRIPTION
Closes #199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new formatting module to improve log message clarity by displaying floating-point numbers with three decimal places.
- **Enhancements**
	- Added a macro for consistent formatting of floating-point values in log messages, enhancing readability and debugging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->