### PR TITLE
Use actions that are slightly better maintained

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
         with:
           toolchain: stable
           components: clippy
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
         with:
           toolchain: stable
           components: clippy
@@ -110,7 +110,7 @@ jobs:
         run: /usr/bin/docker run -d --name envoy --network "${{ job.container.network }}" --network-alias envoy -p 8080:8080 -e GITHUB_ACTIONS=true -e CI=true -v "./tests/gha_envoy.yaml":"/etc/envoy/envoy.yaml" envoyproxy/envoy:v${{ matrix.envoy-version }}-latest envoy -l debug -c /etc/envoy/envoy.yaml
 
       - name: Install Rust
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
@@ -124,7 +124,7 @@ jobs:
         run: /usr/bin/docker ps
 
       - name: Run bulwark tests
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+        uses: clechasseur/rs-cargo@cc6f4abbeb8d498b2c6637af19ac691f8540f8d1 # v2.0.2
         with:
           command: test
           args: -p bulwark-cli -p bulwark-build -p bulwark-config -p bulwark-decision -p bulwark-ext-processor -p bulwark-wasm-host -p bulwark-wasm-sdk -p bulwark-wasm-sdk-macros -- --include-ignored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-          override: true
           target: wasm32-wasi
 
       - name: Rust cache
@@ -52,7 +51,6 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-          override: true
           target: wasm32-wasi
 
       - name: Rust cache
@@ -114,7 +112,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-          override: true
           target: wasm32-wasi
 
       - name: Rust cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83
+      - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
           toolchain: stable
           components: rustfmt
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
+        uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
           toolchain: stable
           components: clippy
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
+        uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
           toolchain: stable
           components: clippy
@@ -110,7 +110,7 @@ jobs:
         run: /usr/bin/docker run -d --name envoy --network "${{ job.container.network }}" --network-alias envoy -p 8080:8080 -e GITHUB_ACTIONS=true -e CI=true -v "./tests/gha_envoy.yaml":"/etc/envoy/envoy.yaml" envoyproxy/envoy:v${{ matrix.envoy-version }}-latest envoy -l debug -c /etc/envoy/envoy.yaml
 
       - name: Install Rust
-        uses: crusty-pie/toolchain@2aef7f27c22121ea8f16f5448e062bde2d150c4f # v1.0.7
+        uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy


### PR DESCRIPTION
The actions-rs stuff has all been archived. The images are deprecated so it's probably a good idea to switch to something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the toolchain references for Rust setup in GitHub Actions to enhance development workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->