### PR TITLE
This is a better workaround for the missing safety doc in the macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
         uses: swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Run clippy
-        run: cargo clippy --no-deps --workspace --all-targets -- --deny warnings --allow clippy::missing-safety-doc
+        run: cargo clippy --no-deps --workspace --all-targets -- --deny warnings
 
   docs:
     name: Docs

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,5 +1,7 @@
 //! This crate provides the logic for Bulwark's guest environment.
 
+#![allow(clippy::missing_safety_doc)]
+
 pub use bulwark_sdk_macros::{bulwark_plugin, handler};
 
 /// Internally used bindings.


### PR DESCRIPTION
Unfortunately, can't do the same thing inside the `bulwark_plugin` macro, it's not a valid location for an inner attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved code quality by adjusting linting rules related to safety documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->