### PR TITLE
Switch `bb8` out for `deadpool`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,30 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "bb8"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7c2093d15d6a1d33b1f972e1c5ea3177748742b97a5f392aa83a65262c6780"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-util",
- "parking_lot 0.12.1",
- "tokio 1.37.0",
-]
-
-[[package]]
-name = "bb8-redis"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb4f141b33a750b5f667c445bd8588de10b8f2b045cd2aabc040ca746fb53ae"
-dependencies = [
- "async-trait",
- "bb8",
- "redis",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +301,6 @@ dependencies = [
  "anyhow",
  "approx",
  "axum",
- "bb8-redis",
  "bulwark-build",
  "bulwark-config",
  "bulwark-ext-processor",
@@ -337,6 +312,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "color-eyre",
+ "deadpool-redis",
  "envoy-control-plane",
  "http 1.0.0",
  "hyper 1.2.0",
@@ -374,6 +350,7 @@ dependencies = [
  "chrono",
  "itertools 0.12.0",
  "lazy_static",
+ "num_cpus",
  "regex",
  "serde",
  "serde_json",
@@ -398,11 +375,11 @@ dependencies = [
 name = "bulwark-ext-processor"
 version = "0.5.0"
 dependencies = [
- "bb8-redis",
  "bulwark-config",
  "bulwark-host",
  "bulwark-sdk",
  "bytes 1.5.0",
+ "deadpool-redis",
  "envoy-control-plane",
  "forwarded-header-value",
  "futures 0.3.29",
@@ -428,12 +405,12 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bb8-redis",
  "bulwark-build",
  "bulwark-config",
  "bulwark-sdk",
  "bytes 1.5.0",
  "chrono",
+ "deadpool-redis",
  "futures 0.3.29",
  "http 1.0.0",
  "http-body-util",
@@ -1059,6 +1036,36 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "deadpool"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f5e4b9ce67c972acc225e71aefe6b21241276f94005024562874611064d30"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio 1.37.0",
+]
+
+[[package]]
+name = "deadpool-redis"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2244d421c9514eab2e1ce1aa1e3c9d5c7cbb9cf3d9bbcac21a6b27e6a868d84"
+dependencies = [
+ "deadpool",
+ "redis",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
+dependencies = [
+ "tokio 1.37.0",
+]
 
 [[package]]
 name = "debugid"
@@ -1970,16 +1977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,19 +2395,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.3",
+ "lock_api",
+ "parking_lot_core",
  "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api 0.4.11",
- "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2426,19 +2413,6 @@ dependencies = [
  "rustc_version",
  "smallvec 0.6.14",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall 0.4.1",
- "smallvec 1.13.2",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3627,7 +3601,6 @@ dependencies = [
  "libc",
  "mio 0.8.9",
  "num_cpus",
- "parking_lot 0.12.1",
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio-macros",
@@ -3731,7 +3704,7 @@ dependencies = [
  "log",
  "mio 0.6.23",
  "num_cpus",
- "parking_lot 0.9.0",
+ "parking_lot",
  "slab",
  "tokio-executor",
  "tokio-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bulwark-host = { workspace = true }
 bulwark-sdk = { workspace = true }
 
 anyhow = { workspace = true }
-bb8-redis = { workspace = true }
+deadpool-redis = { workspace = true }
 bytes = { workspace = true }
 reqwest = { workspace = true }
 approx = { workspace = true }
@@ -119,7 +119,7 @@ forwarded-header-value = "0.1.1"
 futures = "0.3"
 http = "1.0"
 metrics = "0.21.1"
-bb8-redis = "0.15.0"
+deadpool-redis = "0.15.0"
 redis = { version = "0.25", features = [
     "tokio-comp",
     "tokio-rustls-comp",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,6 +26,7 @@ validator = { workspace = true }
 itertools = "0.12.0"
 lazy_static = "1.4.0"
 regex = "1.9.1"
+num_cpus = "^1.11.1"
 
 [dev-dependencies]
 bulwark-build = { workspace = true }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -130,19 +130,16 @@ impl Default for Runtime {
 pub struct State {
     /// The URI for the external Redis state store.
     pub redis_uri: Option<String>,
-    /// The size of the remote state connection pool.
-    pub redis_pool_size: u32,
+    /// The size of the Redis connection pool.
+    pub redis_pool_size: usize,
 }
-
-/// The default [`State::redis_pool_size`] value.
-pub const DEFAULT_REDIS_POOL_SIZE: u32 = 16;
 
 impl Default for State {
     /// Default runtime config
     fn default() -> Self {
         Self {
             redis_uri: None,
-            redis_pool_size: DEFAULT_REDIS_POOL_SIZE,
+            redis_pool_size: num_cpus::get_physical() * 4,
         }
     }
 }

--- a/crates/config/src/toml.rs
+++ b/crates/config/src/toml.rs
@@ -142,7 +142,7 @@ struct State {
     #[serde(default = "default_redis_uri")]
     redis_uri: Option<String>,
     #[serde(default = "default_redis_pool_size")]
-    redis_pool_size: u32,
+    redis_pool_size: usize,
 }
 
 /// The default for the network address to access remote state.
@@ -151,8 +151,8 @@ fn default_redis_uri() -> Option<String> {
 }
 
 /// The default for the remote state connection pool size.
-fn default_redis_pool_size() -> u32 {
-    crate::DEFAULT_REDIS_POOL_SIZE
+fn default_redis_pool_size() -> usize {
+    num_cpus::get_physical() * 4
 }
 
 impl Default for State {
@@ -763,7 +763,9 @@ mod tests {
             root.state.redis_uri,
             Some(String::from("redis://127.0.0.1:6379"))
         );
-        assert_eq!(root.state.redis_pool_size, crate::DEFAULT_REDIS_POOL_SIZE);
+        // We don't know how many CPUs will be present but we know it's not zero,
+        // so pool size has to be at least 4.
+        assert!(root.state.redis_pool_size >= 4);
 
         assert_eq!(root.metrics.statsd_host, Some(String::from("10.0.0.2")));
         assert_eq!(root.metrics.statsd_port, Some(8125));

--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -18,7 +18,7 @@ bulwark-config = { workspace = true }
 bulwark-host = { workspace = true }
 bulwark-sdk = { workspace = true }
 
-bb8-redis = { workspace = true }
+deadpool-redis = { workspace = true }
 envoy-control-plane = { workspace = true }
 forwarded-header-value = { workspace = true }
 futures = { workspace = true }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -24,7 +24,7 @@ wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 
 anyhow = { workspace = true }
-bb8-redis = { workspace = true }
+deadpool-redis = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }

--- a/crates/host/src/context.rs
+++ b/crates/host/src/context.rs
@@ -1,6 +1,5 @@
 use crate::{ContextInstantiationError, Plugin, PluginStdio};
 
-use bb8_redis::{bb8, RedisConnectionManager};
 use chrono::Utc;
 use core::{future::Future, marker::Send, pin::Pin};
 use redis::AsyncCommands;
@@ -43,7 +42,7 @@ pub struct RedisCtx {
     /// A Lua script registry
     pub registry: Arc<ScriptRegistry>,
     /// The connection pool
-    pub pool: Option<Arc<bb8::Pool<RedisConnectionManager>>>,
+    pub pool: Option<Arc<deadpool_redis::Pool>>,
 }
 
 /// A registry of predefined Lua scripts for execution within Redis.

--- a/crates/host/src/errors.rs
+++ b/crates/host/src/errors.rs
@@ -6,6 +6,8 @@ pub enum PluginLoadError {
     #[error(transparent)]
     StringArray(#[from] wasi_common::StringArrayError),
     #[error(transparent)]
+    CreatePool(#[from] deadpool_redis::CreatePoolError),
+    #[error(transparent)]
     Resolution(#[from] bulwark_config::ResolutionError),
     #[error("at least one resource required")]
     ResourceMissing,


### PR DESCRIPTION
Closes #216.

This also changes the default pool size from 16 to 4x CPU count, to match up with `deadpool-redis`'s default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `num_cpus` as a dependency to enhance performance calculations.
- **Refactor**
	- Updated Redis connection pooling by replacing `bb8-redis` with `deadpool-redis` across various components.
	- Adjusted `redis_pool_size` field type and default value calculation for improved efficiency based on system resources.
- **Bug Fixes**
	- Fixed Redis connection pool handling and configuration to utilize `deadpool_redis`.
- **Documentation**
	- Added documentation for new error variant related to Redis pool creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->