### PR TITLE
Add License README section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,13 @@ that the software will remain available under its current license.
 
 [good-first-issue]: https://github.com/bulwark-security/bulwark/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 
+### 🤝 License
+
+This project is licensed under the Apache 2.0 license with the LLVM exception. See LICENSE for more details.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this project
+by you, as defined in the Apache 2.0 license, shall be licensed as above, without any additional terms or conditions.
+
 ## 🛟 Getting Help
 
 To start, check if the answer to your question can be found in any of the [guides](https://docs.bulwark.security/guides)


### PR DESCRIPTION
Just setting clear expectations, similar to what the Bytecode Alliance is doing on their projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to include a section on the project's license, specifically Apache 2.0 with the LLVM exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->