### PR TITLE
Don't re-export types when we're already re-exporting their module.

### DIFF
--- a/crates/sdk/src/host_api.rs
+++ b/crates/sdk/src/host_api.rs
@@ -9,16 +9,16 @@ pub use crate::{Decision, Outcome};
 pub use serde_json::json as value;
 pub use serde_json::{Map, Value};
 
-/// A type alias. See [`bytes::Bytes`](https://docs.rs/bytes/latest/bytes/struct.Bytes.html) for details.
-pub type Bytes = bytes::Bytes;
-/// An HTTP request combines a head consisting of a [`Method`], [`Uri`], and headers with [`Bytes`], which provides
-/// access to the first chunk of a request body.
-pub type Request = http::Request<Bytes>;
-/// An HTTP response combines a head consisting of a [`StatusCode`] and headers with [`Bytes`], which provides
-/// access to the first chunk of a response body.
-pub type Response = http::Response<Bytes>;
 /// Reexports the `http` crate.
 pub use http;
+/// A type alias. See [`bytes::Bytes`](https://docs.rs/bytes/latest/bytes/struct.Bytes.html) for details.
+pub type Bytes = bytes::Bytes;
+/// An HTTP request combines a head consisting of a [`Method`](http::Method), [`Uri`](http::Uri), and headers with [`Bytes`], which provides
+/// access to the first chunk of a request body.
+pub type Request = http::Request<Bytes>;
+/// An HTTP response combines a head consisting of a [`StatusCode`](http::StatusCode) and headers with [`Bytes`], which provides
+/// access to the first chunk of a response body.
+pub type Response = http::Response<Bytes>;
 
 // TODO: perhaps something more like http::Request<Box<dyn AsyncRead + Sync + Send + Unpin>>?
 // TODO: or hyper::Request<HyperIncomingBody> to match WasiHttpView's new_incoming_request?

--- a/crates/sdk/src/host_api.rs
+++ b/crates/sdk/src/host_api.rs
@@ -6,7 +6,6 @@ use {
 // For some reason, doc-tests in this module trigger a linker error, so they're set to no_run
 
 pub use crate::{Decision, Outcome};
-pub use http::{Extensions, Method, StatusCode, Uri, Version};
 pub use serde_json::json as value;
 pub use serde_json::{Map, Value};
 

--- a/tests/plugins/multi-phase-plugin-a/src/lib.rs
+++ b/tests/plugins/multi-phase-plugin-a/src/lib.rs
@@ -42,20 +42,20 @@ impl HttpHandlers for AlicePlugin {
         if let Some(overwrite) = labels.get("overwrite") {
             assert_eq!(overwrite.as_str(), "new value");
         }
-        if response.status() == StatusCode::OK && request.method() == "POST" {
+        if response.status() == http::StatusCode::OK && request.method() == "POST" {
             // This needs to be low enough that it doesn't trigger a block on its own, but
             // high enough that it triggers a block only when combined with another restrict
             // value that originated in a _request_ phase in a different plugin that similarly
             // isn't enough to block on its own. This has to be triggered by the Envoy
             // integration test to hit the behavior this is intended to verify.
             output.decision = Decision::restricted(0.5);
-        } else if response.status() == StatusCode::NOT_FOUND {
+        } else if response.status() == http::StatusCode::NOT_FOUND {
             if let Some(overwrite) = labels.get("overwrite") {
                 if overwrite.as_str() == "new value" {
                     output.decision = Decision::restricted(0.1);
                 }
             }
-        } else if response.status() == StatusCode::INTERNAL_SERVER_ERROR {
+        } else if response.status() == http::StatusCode::INTERNAL_SERVER_ERROR {
             return Err(error!(
                 "this is an intentional error to force the error tag"
             ));


### PR DESCRIPTION
Closes #270.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Streamlined HTTP-related exports in the SDK for better usability and consistency.
- **Tests**
	- Updated plugin tests to align with the latest SDK changes, ensuring compatibility.
- **Chores**
	- Removed unnecessary exports from the `host_api.rs` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->