### PR TITLE
Use clone_from instead of clone

### DIFF
--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -737,7 +737,7 @@ impl ProcessorContext {
             tags: self.combined_output.tags.clone(),
             labels,
         };
-        self.plugin_outputs = plugin_outputs.clone();
+        self.plugin_outputs.clone_from(&plugin_outputs);
     }
 
     async fn execute_response_phase(&mut self) {
@@ -852,7 +852,7 @@ impl ProcessorContext {
             tags: self.combined_output.tags.clone(),
             labels,
         };
-        self.plugin_outputs = new_plugin_outputs.clone();
+        self.plugin_outputs.clone_from(&new_plugin_outputs);
     }
 
     async fn execute_decision_feedback(&mut self) {


### PR DESCRIPTION
Fixes clippy warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of data handling in the processing service by optimizing how outputs are assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->