### PR TITLE
Revert "Bump matchit from 0.7.3 to 0.8.2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -392,7 +392,7 @@ dependencies = [
  "futures 0.3.30",
  "http 1.1.0",
  "json",
- "matchit 0.8.2",
+ "matchit",
  "metrics",
  "prost 0.12.4",
  "prost-wkt",
@@ -2022,12 +2022,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540f1c43aed89909c0cc0cc604e3bb2f7e7a341a3728a9e6cfe760e733cd11ed"
 
 [[package]]
 name = "maybe-owned"

--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { workspace = true }
 
 bytes = "1"
 json = "0.12.4"
-matchit = "0.8.2"
+matchit = "0.7.0"
 prost = "0.12"
 prost-wkt = "=0.3.0"
 sfv = "0.9.2"


### PR DESCRIPTION
Reverts bulwark-security/bulwark#286.

Broke router behavior. Notably didn't cause tests to fail, so we need to create a tracking issue for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded the `matchit` dependency from version `0.8.2` to `0.7.0` to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->