### PR TITLE
Strip out `pbjson` since we don't need it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,12 +291,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -441,10 +435,8 @@ dependencies = [
  "json",
  "matchit",
  "metrics",
- "pbjson",
- "pbjson-build 0.6.2",
- "pbjson-types",
- "prost 0.11.9",
+ "prost",
+ "prost-types",
  "redis",
  "redis-test",
  "serde",
@@ -1860,15 +1852,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2434,55 +2417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pbjson"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
-dependencies = [
- "base64 0.13.1",
- "serde",
-]
-
-[[package]]
-name = "pbjson-build"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
-dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
- "prost 0.11.9",
- "prost-types 0.11.9",
-]
-
-[[package]]
-name = "pbjson-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
-dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
- "prost 0.12.4",
- "prost-types 0.12.4",
-]
-
-[[package]]
-name = "pbjson-types"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a88c8d87f99a4ac14325e7a4c24af190fca261956e3b82dd7ed67e77e6c7043"
-dependencies = [
- "bytes 1.6.0",
- "chrono",
- "pbjson",
- "pbjson-build 0.5.1",
- "prost 0.11.9",
- "prost-build",
- "serde",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,17 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.6.0",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
-dependencies = [
- "bytes 1.6.0",
- "prost-derive 0.12.5",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2631,8 +2555,8 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "prost",
+ "prost-types",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -2653,34 +2577,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.61",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
-dependencies = [
- "prost 0.12.4",
+ "prost",
 ]
 
 [[package]]
@@ -3902,7 +3804,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.9",
+ "prost",
  "tokio 1.37.0",
  "tokio-stream",
  "tower",

--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -34,16 +34,13 @@ bytes = "1"
 json = "0.12.4"
 matchit = "0.7.0"
 prost = "^0.11"
+prost-types = "^0.11"
 sfv = "0.9.2"
-pbjson = "^0.5"
-pbjson-types = "^0.5"
-# typetag = "^0.2"
 
 [dev-dependencies]
 redis-test = { workspace = true }
 
 [build-dependencies]
-pbjson-build = "0.6.2"
 tonic-build = "0.9.2"
 
 [lib]

--- a/crates/ext-processor/build.rs
+++ b/crates/ext-processor/build.rs
@@ -13,8 +13,6 @@ fn main() -> Result<()> {
         .build_server(true)
         .build_client(false)
         .file_descriptor_set_path(descriptor_path.clone())
-        .compile_well_known_types(true)
-        .extern_path(".google.protobuf", "::pbjson_types")
         .compile(
             &[
                 "protobuf/data-plane-api/envoy/config/common/mutation_rules/v3/mutation_rules.proto",

--- a/crates/ext-processor/src/protobuf.rs
+++ b/crates/ext-processor/src/protobuf.rs
@@ -21,6 +21,7 @@ pub mod envoy {
         pub mod filters {
             pub mod http {
                 pub mod ext_authz {
+                    #[allow(clippy::large_enum_variant)]
                     pub mod v3 {
                         include!(concat!(
                             env!("OUT_DIR"),


### PR DESCRIPTION
We removed most of the JSON stuff for protobufs, but didn't remove the `pbjson` dependency. This removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved protobuf compilation settings for better performance and compatibility.

- **Chores**
  - Updated and streamlined dependencies for more efficient builds.

- **Refactor**
  - Removed unnecessary configurations to simplify build processes.
  - Added code quality attribute to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->