### PR TITLE
Add default/fallback resources

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -444,13 +444,31 @@ impl Preset {
     }
 }
 
+/// A route pattern is either a default route that matches anything or a path-based route pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RoutePattern {
+    /// Matches any request not matched by a path-based route.
+    Default,
+    /// Matches requests that correspond to the enclosed path pattern.
+    Path(String),
+}
+
+impl Display for RoutePattern {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Self::Default => write!(f, "[default route]"),
+            Self::Path(route) => write!(f, "[{}]", route),
+        }
+    }
+}
+
 /// A mapping between a route pattern and the plugins that should be run for matching requests.
 #[derive(Debug, Clone)]
 pub struct Resource {
     /// The route pattern used to match requests with.
     ///
     /// Uses `matchit` router patterns.
-    pub route: String,
+    pub route: RoutePattern,
     /// The plugin references for this route.
     pub plugins: Vec<Reference>,
     /// The maximum amount of time a plugin may take for each execution phase.

--- a/crates/config/src/errors.rs
+++ b/crates/config/src/errors.rs
@@ -25,6 +25,8 @@ pub enum ConfigFileError {
     InvalidSecretConfig(String),
     #[error("invalid plugin config: {0}")]
     InvalidPluginConfig(String),
+    #[error("invalid resource config: {0}")]
+    InvalidResourceConfig(String),
 }
 
 /// This error will be returned if an attempt to serialize a config structure fails.

--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -98,6 +98,7 @@ async fn join_all<T, F>(
 pub struct BulwarkProcessor {
     // TODO: may need to have a plugin registry at some point
     router: Arc<RwLock<Router<RouteTarget>>>,
+    default_route: Arc<RwLock<Option<RouteTarget>>>,
     redis_ctx: RedisCtx,
     request_semaphore: Arc<tokio::sync::Semaphore>,
     plugin_semaphore: Arc<tokio::sync::Semaphore>,
@@ -156,59 +157,55 @@ impl ExternalProcessor for BulwarkProcessor {
                     );
 
                     let router = bulwark_processor.router.read().await;
+                    let default_route = bulwark_processor.default_route.read().await;
+                    let mut router_labels = HashMap::new();
                     let route_result = router.at(request.uri().path());
                     // TODO: router needs to point to a struct that bundles the plugin set and associated config like timeout duration
                     // TODO: put default timeout in a constant somewhere central
                     let mut timeout_duration = Duration::from_millis(10);
-                    match route_result {
+                    let route_target = match route_result {
                         Ok(route_match) => {
                             // TODO: may want to expose labels to logging after redaction
-                            let mut router_labels = HashMap::new();
                             for (key, value) in route_match.params.iter() {
                                 router_labels.insert(format!("route.{}", key), value.to_string());
                             }
-
-                            let route_target = route_match.value;
-                            // TODO: figure out how best to bubble the error out of the task and up to the parent
-                            // TODO: figure out if tonic-error or some other option is the best way to convert to a tonic Status error
-                            // TODO: we probably want to be initializing only when necessary now rather than on every request
-                            let plugin_instances = bulwark_processor
-                                .instantiate_plugins(&route_target.plugins)
-                                .await
-                                .unwrap();
-                            if let Some(millis) = route_match.value.timeout {
-                                timeout_duration = Duration::from_millis(millis);
-                            }
-
-                            let mut ctx = ProcessorContext {
-                                sender: arc_sender,
-                                stream: arc_stream,
-                                plugin_semaphore,
-                                plugin_instances: plugin_instances.clone(),
-                                router_labels,
-                                request: request.clone(),
-                                response: None,
-                                verdict: None,
-                                combined_output: HandlerOutput::default(),
-                                plugin_outputs: HashMap::new(),
-                                thresholds,
-                                timeout_duration,
-                            };
-
-                            ctx.execute_init_phase().await;
-
-                            ctx.execute_request_enrichment_phase().await;
-                            ctx.execute_request_decision_phase().await;
-
-                            ctx.complete_request_phase().await;
+                            route_match.value
                         }
-                        Err(_) => {
-                            // TODO: figure out how best to handle trailing slash errors, silent failure is probably undesirable
-                            error!(uri = request.uri().to_string(), message = "match error");
-                            // TODO: panic is undesirable, need to figure out if we should be returning a Status or changing the response or doing something else
-                            panic!("match error");
-                        }
+                        Err(_) => default_route.as_ref().expect("match error"),
                     };
+
+                    // TODO: figure out how best to bubble the error out of the task and up to the parent
+                    // TODO: figure out if tonic-error or some other option is the best way to convert to a tonic Status error
+                    // TODO: we probably want to be initializing only when necessary now rather than on every request
+                    let plugin_instances = bulwark_processor
+                        .instantiate_plugins(&route_target.plugins)
+                        .await
+                        .unwrap();
+                    if let Some(millis) = route_target.timeout {
+                        timeout_duration = Duration::from_millis(millis);
+                    }
+
+                    let mut ctx = ProcessorContext {
+                        sender: arc_sender,
+                        stream: arc_stream,
+                        plugin_semaphore,
+                        plugin_instances: plugin_instances.clone(),
+                        router_labels,
+                        request: request.clone(),
+                        response: None,
+                        verdict: None,
+                        combined_output: HandlerOutput::default(),
+                        plugin_outputs: HashMap::new(),
+                        thresholds,
+                        timeout_duration,
+                    };
+
+                    ctx.execute_init_phase().await;
+
+                    ctx.execute_request_enrichment_phase().await;
+                    ctx.execute_request_decision_phase().await;
+
+                    ctx.complete_request_phase().await;
                 }
                 drop(permit);
             }
@@ -269,6 +266,7 @@ impl BulwarkProcessor {
         };
 
         let mut router: Router<RouteTarget> = Router::new();
+        let mut default_route = None;
         if config.resources.is_empty() {
             // TODO: return an init error not a plugin load error
             return Err(PluginLoadError::ResourceMissing);
@@ -281,24 +279,38 @@ impl BulwarkProcessor {
                 debug!(
                     message = "load plugin",
                     location = tracing::field::display(&plugin_config.location),
-                    resource = resource.route
+                    resource = tracing::field::display(&resource.route),
                 );
                 let plugin = Plugin::from_config(&config, plugin_config)?;
                 plugins.push(Arc::new(plugin));
             }
-            router
-                .insert(
-                    resource.route.clone(),
-                    // TODO: the route target will probably need access to the route itself in the future
-                    RouteTarget {
+            match &resource.route {
+                bulwark_config::RoutePattern::Default => {
+                    if default_route.is_some() {
+                        return Err(PluginLoadError::MultipleDefaultRoutes);
+                    }
+                    default_route = Some(RouteTarget {
                         timeout: resource.timeout,
                         plugins,
-                    },
-                )
-                .ok();
+                    });
+                }
+                bulwark_config::RoutePattern::Path(route) => {
+                    router
+                        .insert(
+                            route,
+                            // TODO: the route target will probably need access to the route itself in the future
+                            RouteTarget {
+                                timeout: resource.timeout,
+                                plugins,
+                            },
+                        )
+                        .ok();
+                }
+            }
         }
         Ok(Self {
             router: Arc::new(RwLock::new(router)),
+            default_route: Arc::new(RwLock::new(default_route)),
             request_semaphore: Arc::new(Semaphore::new(config.runtime.max_concurrent_requests)),
             plugin_semaphore: Arc::new(Semaphore::new(config.runtime.max_plugin_tasks)),
             thresholds: config.thresholds,

--- a/crates/host/src/errors.rs
+++ b/crates/host/src/errors.rs
@@ -11,6 +11,8 @@ pub enum PluginLoadError {
     Resolution(#[from] bulwark_config::ResolutionError),
     #[error("at least one resource required")]
     ResourceMissing,
+    #[error("at most one default route allowed")]
+    MultipleDefaultRoutes,
     #[error("missing secret: '{0}'")]
     SecretMissing(String),
     #[error("unreadable secret: '{0}': {1}")]


### PR DESCRIPTION
Simplifies the very common case of using the same plugin set for everything. There might be an argument that the default route should just be a wildcard route pattern perhaps after addressing #74 or introducing more convenient ways of prefix matching against a prefix of `"/"`, but until we have that, a fallback route works.

For context, currently, a route of `"/"` will match a URI path of `"/"` and nothing else, while a route of `"/*params"` will match every URI path except `"/"`. A route of `"/*"` doesn't result in an error but doesn't seem to match anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced support for different route patterns in resource configurations, enhancing flexibility in defining routes.
  - Added handling for default routes in resource processing.

- **Bug Fixes**
  - Improved error handling with new error variants to provide clearer diagnostics for configuration and plugin loading issues.

- **Refactor**
  - Updated internal structures to support new routing patterns and default route logic, improving overall maintainability and extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->