### PR TITLE
This dependency doesn't seem to be used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
  "forwarded-header-value",
  "futures",
  "http 1.1.0",
- "json",
  "matchit 0.8.2",
  "metrics",
  "prost",
@@ -1807,12 +1806,6 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/crates/ext-processor/Cargo.toml
+++ b/crates/ext-processor/Cargo.toml
@@ -32,7 +32,6 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 
 bytes = "1"
-json = "0.12.4"
 prost = "^0.11"
 prost-types = "^0.11"
 sfv = "0.9.2"


### PR DESCRIPTION
It's getting flagged due to being unmaintained, but more importantly, it doesn't seem to be used anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the `json` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->