### PR TITLE
Allow numbers in references as long as they're not first letter

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -12,7 +12,7 @@ use url::Url;
 use validator::Validate;
 
 lazy_static! {
-    static ref RE_VALID_REFERENCE: Regex = Regex::new(r"^[_a-z]+$").unwrap();
+    static ref RE_VALID_REFERENCE: Regex = Regex::new(r"^[a-z_]([a-z0-9_])*$").unwrap();
 }
 
 /// The root of a Bulwark configuration.

--- a/crates/config/tests/invalid_plugin_reference.toml
+++ b/crates/config/tests/invalid_plugin_reference.toml
@@ -1,0 +1,9 @@
+[[plugin]]
+ref = "not/okay-reference"
+path = "bulwark_blank_slate.wasm"
+config = {}
+
+[[resource]]
+routes = ["/"]
+plugins = ["not/okay-reference"]
+timeout = 25

--- a/crates/config/tests/valid_numeric_plugin_reference.toml
+++ b/crates/config/tests/valid_numeric_plugin_reference.toml
@@ -1,0 +1,9 @@
+[[plugin]]
+ref = "blank_slate_v2"
+path = "bulwark_blank_slate.wasm"
+config = {}
+
+[[resource]]
+routes = ["/"]
+plugins = ["blank_slate_v2"]
+timeout = 25


### PR DESCRIPTION
Fixes #110.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Changed validation for plugin references to support alphanumeric characters and underscores.

- **Tests**
  - Introduced new test cases to ensure proper handling of numeric and invalid plugin references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->