### PR TITLE
Use `async_trait` macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ wit-component = "0.208.1"
 # Other shared external dependencies
 anyhow = "=1.0.72"
 approx = "0.5"
+async-trait = "0.1.74"
 axum = { version = "0.7.5", features = ["http2"] }
 bytes = "1.5"
 chrono = { version = "0.4.26", features = ["serde"] }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -24,6 +24,7 @@ wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 deadpool-redis = { workspace = true }
@@ -40,7 +41,6 @@ thiserror = { workspace = true }
 url = { workspace = true }
 validator = { workspace = true }
 
-async-trait = "0.1.68"
 http-body-util = "0.1.0"
 secrecy = "0.8.0"
 


### PR DESCRIPTION
Previous we had `Pin<Box<dyn Future + Send + 'async_trait>>` instead of using the `async_trait` macro.

Fixes #340.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced async support for various host crate functions, enhancing non-blocking performance capabilities.

- **Refactor**
  - Converted synchronous functions to asynchronous in the host crate, simplifying function signatures and improving error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->