### PR TITLE
Add counters to `Verdict`

### DIFF
--- a/crates/ext-processor/src/service.rs
+++ b/crates/ext-processor/src/service.rs
@@ -1006,6 +1006,7 @@ impl ProcessorContext {
                     let verdict = Verdict {
                         decision,
                         outcome,
+                        count: self.plugin_outputs.len() as u32,
                         tags: self.combined_output.tags.iter().cloned().collect(),
                     };
                     self.response = Some(Arc::new(response));
@@ -1019,6 +1020,7 @@ impl ProcessorContext {
                     let verdict = Verdict {
                         decision,
                         outcome,
+                        count: self.plugin_outputs.len() as u32,
                         tags: self.combined_output.tags.iter().cloned().collect(),
                     };
                     self.verdict = Some(verdict);
@@ -1113,6 +1115,7 @@ impl ProcessorContext {
         let verdict = bulwark_sdk::Verdict {
             decision,
             outcome,
+            count: self.plugin_outputs.len() as u32,
             tags: self.combined_output.tags.iter().cloned().collect(),
         };
         self.verdict = Some(verdict);

--- a/crates/host/src/from.rs
+++ b/crates/host/src/from.rs
@@ -123,6 +123,7 @@ impl From<Verdict> for crate::bindings::bulwark::plugin::types::Verdict {
         crate::bindings::bulwark::plugin::types::Verdict {
             outcome: verdict.outcome.into(),
             decision: verdict.decision.into(),
+            count: verdict.count,
             tags: verdict.tags.clone(),
         }
     }

--- a/crates/sdk-macros/src/lib.rs
+++ b/crates/sdk-macros/src/lib.rs
@@ -272,6 +272,7 @@ pub fn bulwark_plugin(_: TokenStream, input: TokenStream) -> TokenStream {
                 Self {
                     decision: verdict.decision.into(),
                     outcome: verdict.outcome.into(),
+                    count: verdict.count,
                     tags: verdict.tags.clone(),
                 }
             }

--- a/crates/sdk/src/from.rs
+++ b/crates/sdk/src/from.rs
@@ -25,6 +25,7 @@ impl From<Verdict> for crate::wit::bulwark::plugin::types::Verdict {
         crate::wit::bulwark::plugin::types::Verdict {
             outcome: verdict.outcome.into(),
             decision: verdict.decision.into(),
+            count: verdict.count,
             tags: verdict.tags.clone(),
         }
     }

--- a/crates/sdk/src/host_api.rs
+++ b/crates/sdk/src/host_api.rs
@@ -31,6 +31,8 @@ pub struct Verdict {
     pub decision: Decision,
     /// The `outcome` value represents a comparison of the numerical decision against a set of thresholds.
     pub outcome: Outcome,
+    /// The `count` value represents the number of plugins that contributed to the decision.
+    pub count: u32,
     /// The `tags` value represents the merged tags used to annotate the request.
     pub tags: Vec<String>,
 }

--- a/tests/exec_plugin.rs
+++ b/tests/exec_plugin.rs
@@ -90,6 +90,7 @@ fn test_blank_slate_exec() -> Result<(), Box<dyn std::error::Error>> {
         bulwark_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_sdk::Outcome::Accepted,
+            count: 1,
             tags: tags.iter().cloned().collect(),
         },
     ))?;
@@ -185,6 +186,7 @@ fn test_evil_bit_benign_exec() -> Result<(), Box<dyn std::error::Error>> {
         bulwark_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_sdk::Outcome::Accepted,
+            count: 1,
             tags: tags.iter().cloned().collect(),
         },
     ))?;
@@ -198,14 +200,14 @@ fn test_evil_bit_evil_exec() -> Result<(), Box<dyn std::error::Error>> {
 
     bulwark_build::build_plugin(
         base.join("../crates/sdk/examples/evil-bit"),
-        base.join("dist/plugins/evil-bit.wasm"),
+        base.join("dist/plugins/bulwark_evil_bit.wasm"),
         &[],
         true,
     )?;
-    assert!(base.join("dist/plugins/evil-bit.wasm").exists());
+    assert!(base.join("dist/plugins/bulwark_evil_bit.wasm").exists());
 
     let plugin = Arc::new(Plugin::from_file(
-        base.join("dist/plugins/evil-bit.wasm"),
+        base.join("dist/plugins/bulwark_evil_bit.wasm"),
         // None of this config will get read during this test.
         &bulwark_config::Config {
             service: bulwark_config::Service::default(),
@@ -271,6 +273,7 @@ fn test_evil_bit_evil_exec() -> Result<(), Box<dyn std::error::Error>> {
         bulwark_sdk::Verdict {
             decision: handler_output.decision,
             outcome: bulwark_sdk::Outcome::Restricted,
+            count: 1,
             tags: tags.iter().cloned().collect(),
         },
     ))?;

--- a/tests/multi_phase.rs
+++ b/tests/multi_phase.rs
@@ -251,6 +251,7 @@ fn test_multi_phase_exec_post_request() -> Result<(), Box<dyn std::error::Error>
         bulwark_sdk::Verdict {
             decision: resp_combined_decision,
             outcome,
+            count: 2,
             tags: combined_tags.clone(),
         },
     ))?;
@@ -458,6 +459,7 @@ fn test_multi_phase_exec_get_request() -> Result<(), Box<dyn std::error::Error>>
         bulwark_sdk::Verdict {
             decision: resp_combined_decision,
             outcome,
+            count: 2,
             tags: combined_tags.clone(),
         },
     ))?;
@@ -694,6 +696,7 @@ fn test_multi_phase_exec_route_labels() -> Result<(), Box<dyn std::error::Error>
         bulwark_sdk::Verdict {
             decision: resp_combined_decision,
             outcome,
+            count: 2,
             tags: combined_tags.clone(),
         },
     ))?;

--- a/tests/redis.rs
+++ b/tests/redis.rs
@@ -136,6 +136,7 @@ async fn test_redis_plugin() -> Result<(), Box<dyn std::error::Error>> {
             bulwark_sdk::Verdict {
                 decision: handler_output.decision,
                 outcome: bulwark_sdk::Outcome::Accepted,
+                count: 1,
                 tags: tags.iter().cloned().collect(),
             },
         )

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -51,6 +51,8 @@ interface types {
         decision: decision,
         /// The `outcome` value represents a comparison of the numerical decision against a set of thresholds.
         outcome: outcome,
+        /// The `count` value represents the number of plugins that contributed to the decision.
+        count: u32,
         /// The `tags` value represents the merged tags used to annotate the request.
         tags: list<string>,
     }


### PR DESCRIPTION
Fixes #83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `count` field to the `Verdict` struct, representing the number of plugins contributing to the decision.

- **Bug Fixes**
  - Updated error messages to provide more context during interface linking and instantiation failures.

- **Tests**
  - Enhanced various test cases to include the new `count` field in the `Verdict` struct.
  - Updated plugin paths in tests from `evil-bit` to `bulwark_evil_bit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->