### PR TITLE
Exit with error code if service can't start.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch Envoy service
-        run: /usr/bin/docker run -d --name envoy --network "${{ job.container.network }}" --network-alias envoy -p 8080:8080 -e GITHUB_ACTIONS=true -e CI=true -v "./tests/gha_envoy.yaml":"/etc/envoy/envoy.yaml" envoyproxy/envoy:v${{ matrix.envoy-version }}-latest envoy -l debug -c /etc/envoy/envoy.yaml
+        run: /usr/bin/docker run -d --name envoy --network "${{ job.container.network }}" --network-alias envoy -p 4080:4080 -e GITHUB_ACTIONS=true -e CI=true -v "./tests/gha_envoy.yaml":"/etc/envoy/envoy.yaml" envoyproxy/envoy:v${{ matrix.envoy-version }}-latest envoy -l debug -c /etc/envoy/envoy.yaml
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,14 +279,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             while let Some(r) = service_tasks.join_next().await {
                 match r {
                     Ok(Ok(_)) => {}
-                    Ok(Err(e)) => error!(
-                        message = "service could not start",
-                        error_message = ?e,
-                    ),
-                    Err(e) => error!(
-                        message = "join error on service initialization",
-                        error_message = ?e,
-                    ),
+                    Ok(Err(e)) => {
+                        error!(
+                            message = "service could not start",
+                            error_message = ?e,
+                        );
+                        std::process::exit(1);
+                    }
+                    Err(e) => {
+                        error!(
+                            message = "join error on service initialization",
+                            error_message = ?e,
+                        );
+                        std::process::exit(1);
+                    }
                 }
             }
         }

--- a/tests/bulwark.toml
+++ b/tests/bulwark.toml
@@ -1,4 +1,6 @@
 [service]
+# Use a non-default port to avoid collisions with dev servers
+port = 3089
 admin = false
 proxy_hops = 1
 

--- a/tests/envoy.rs
+++ b/tests/envoy.rs
@@ -62,7 +62,6 @@ async fn test_envoy_evil_bit() -> Result<(), Box<dyn std::error::Error>> {
 
     // send a friendly request to our envoy service
     let response = reqwest::get("http://127.0.0.1:4080").await?;
-    println!("{:?}", response);
     assert!(response.status().is_success());
     let body = response.text().await?;
     assert!(body.contains("hello-world"));

--- a/tests/envoy.rs
+++ b/tests/envoy.rs
@@ -51,7 +51,7 @@ async fn test_envoy_evil_bit() -> Result<(), Box<dyn std::error::Error>> {
         // send a throw-away request to make sure everything's launched correctly
         let client = reqwest::Client::new();
         let response = client
-            .post("http://127.0.0.1:8080")
+            .post("http://127.0.0.1:4080")
             .header("Content-Type", "text/html")
             .send()
             .await?;
@@ -61,7 +61,8 @@ async fn test_envoy_evil_bit() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // send a friendly request to our envoy service
-    let response = reqwest::get("http://127.0.0.1:8080").await?;
+    let response = reqwest::get("http://127.0.0.1:4080").await?;
+    println!("{:?}", response);
     assert!(response.status().is_success());
     let body = response.text().await?;
     assert!(body.contains("hello-world"));
@@ -69,7 +70,7 @@ async fn test_envoy_evil_bit() -> Result<(), Box<dyn std::error::Error>> {
     // send an evil request to our envoy service
     let client = reqwest::Client::new();
     let response = client
-        .get("http://127.0.0.1:8080")
+        .get("http://127.0.0.1:4080")
         .header("Evil", "true")
         .send()
         .await?;
@@ -128,7 +129,7 @@ async fn test_envoy_multi_phase_exec() -> Result<(), Box<dyn std::error::Error>>
         // send a throw-away request to make sure everything's launched correctly
         let client = reqwest::Client::new();
         let response = client
-            .post("http://127.0.0.1:8080")
+            .post("http://127.0.0.1:4080")
             .header("Content-Type", "text/html")
             .send()
             .await?;
@@ -140,7 +141,7 @@ async fn test_envoy_multi_phase_exec() -> Result<(), Box<dyn std::error::Error>>
     // send a POST request to our envoy service
     let client = reqwest::Client::new();
     let response = client
-        .post("http://127.0.0.1:8080")
+        .post("http://127.0.0.1:4080")
         .header("Content-Type", "text/html")
         .send()
         .await?;
@@ -151,7 +152,7 @@ async fn test_envoy_multi_phase_exec() -> Result<(), Box<dyn std::error::Error>>
     // send a GET request to our envoy service
     let client = reqwest::Client::new();
     let response = client
-        .get("http://127.0.0.1:8080")
+        .get("http://127.0.0.1:4080")
         .header("Content-Type", "text/html")
         .send()
         .await?;

--- a/tests/gha_envoy.yaml
+++ b/tests/gha_envoy.yaml
@@ -4,7 +4,7 @@ static_resources:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8080
+          port_value: 4080
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager

--- a/tests/gha_envoy.yaml
+++ b/tests/gha_envoy.yaml
@@ -87,4 +87,4 @@ static_resources:
                     # bulwark will be started on the host by the test suite
                     socket_address:
                       address: 172.17.0.1
-                      port_value: 8089
+                      port_value: 3089

--- a/tests/local_envoy.yaml
+++ b/tests/local_envoy.yaml
@@ -4,7 +4,7 @@ static_resources:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8080
+          port_value: 4080
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager

--- a/tests/local_envoy.yaml
+++ b/tests/local_envoy.yaml
@@ -87,4 +87,4 @@ static_resources:
                     # bulwark will be started on the host by the test suite
                     socket_address:
                       address: gateway.docker.internal
-                      port_value: 8089
+                      port_value: 3089

--- a/tests/multi_phase.toml
+++ b/tests/multi_phase.toml
@@ -1,4 +1,6 @@
 [service]
+# Use a non-default port to avoid collisions with dev servers
+port = 3089
 admin = false
 proxy_hops = 1
 


### PR DESCRIPTION
Fixes #274.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated configurations to use non-default ports to avoid collisions with development servers.
	- Improved error handling with more explicit process exits on failures.

- **Tests**
	- Modified HTTP request tests to target a new port for better test environment isolation.
	- Added logging of HTTP responses in specific test scenarios for enhanced debugging.

- **Chores**
	- Updated GitHub Actions workflow to reflect new port mappings for Docker services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->