### PR TITLE
Install protobuf w/ brew instead

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,8 +52,12 @@ jobs:
         components: clippy
         target: wasm32-wasi
 
+    - name: Update Homebrew
+      run: |
+        brew update --preinstall
+
     - name: Install protobuf compiler
-      run: /usr/bin/sudo /usr/bin/apt install -y protobuf-compiler
+      run: /usr/bin/sudo /usr/local/bin/brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2
@@ -83,8 +87,12 @@ jobs:
         components: clippy
         target: wasm32-wasi
 
+    - name: Update Homebrew
+      run: |
+        brew update --preinstall
+
     - name: Install protobuf compiler
-      run: /usr/bin/sudo /usr/bin/apt install -y protobuf-compiler
+      run: /usr/bin/sudo /usr/local/bin/brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2


### PR DESCRIPTION
Mac builds immediately failed because of course `apt` isn't available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to use Homebrew for installing dependencies and updating preinstall commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->