### PR TITLE
Trigger on publish but not create

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ name: "Upload Binaries to GitHub Release"
 
 on:
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
   publish-linux-binary:


### PR DESCRIPTION
Seemed like this was creating double-runs for the action. Not really a problem per-se, but wasteful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the release workflow to trigger only when a release is published, enhancing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->