### PR TITLE
Used the wrong homebrew path

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,10 +54,10 @@ jobs:
 
     - name: Update Homebrew
       run: |
-        brew update --preinstall
+        /usr/bin/brew update --preinstall
 
     - name: Install protobuf compiler
-      run: /usr/bin/sudo /usr/local/bin/brew install protobuf
+      run: /usr/bin/sudo /usr/bin/brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2
@@ -89,10 +89,10 @@ jobs:
 
     - name: Update Homebrew
       run: |
-        brew update --preinstall
+        /usr/bin/brew update --preinstall
 
     - name: Install protobuf compiler
-      run: /usr/bin/sudo /usr/local/bin/brew install protobuf
+      run: /usr/bin/sudo /usr/bin/brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2


### PR DESCRIPTION
Trying to fix the brew path for the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Homebrew and protobuf compiler installation commands in the release workflow to use absolute paths for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->