### PR TITLE
Brew shouldn't be sudo'd

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,7 +57,7 @@ jobs:
         brew update --preinstall
 
     - name: Install protobuf compiler
-      run: sudo brew install protobuf
+      run: brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2
@@ -92,7 +92,7 @@ jobs:
         brew update --preinstall
 
     - name: Install protobuf compiler
-      run: sudo brew install protobuf
+      run: brew install protobuf
 
     - name: Build release target
       uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the installation process for the protobuf compiler by removing the `sudo` command in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->