### PR TITLE
Install the missing `x86_64-apple-darwin` target

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         toolchain: stable
         components: clippy
-        target: wasm32-wasi
+        targets: wasm32-wasi
 
     - name: Install protobuf compiler
       run: /usr/bin/sudo /usr/bin/apt install -y protobuf-compiler
@@ -50,7 +50,7 @@ jobs:
       with:
         toolchain: stable
         components: clippy
-        target: wasm32-wasi
+        targets: wasm32-wasi,x86_64-apple-darwin
 
     - name: Update Homebrew
       run: |
@@ -85,7 +85,7 @@ jobs:
       with:
         toolchain: stable
         components: clippy
-        target: wasm32-wasi
+        targets: wasm32-wasi
 
     - name: Update Homebrew
       run: |


### PR DESCRIPTION
Build failed because `aarch64-apple-darwin` doesn't have `x86_64-apple-darwin` installed by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to support new target `x86_64-apple-darwin`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->