### PR TITLE
Not all generated files were available

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -24,6 +24,12 @@ jobs:
         components: clippy
         target: wasm32-wasi
 
+    - name: Ensure generated files are available
+      uses: clechasseur/rs-cargo@5cd564345ef5b1136392a1dc943b33a3a888b873 # v2.0.2
+      with:
+        command: test
+        args: -p bulwark-config -p bulwark-sdk
+
     - name: Publish Crates
       run: |
         rustc scripts/publish.rs -o /tmp/publish


### PR DESCRIPTION
I manually published the two crates that did go through cleanly, but I think this should prevent that from happening again.