### PR TITLE
Ignore protobuf directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/crates/ext-processor/protobuf/protoc-gen-validate"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/crates/ext-processor/protobuf/protoc-gen-validate"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"

--- a/crates/ext-processor/protobuf/protoc-gen-validate/requirements.txt
+++ b/crates/ext-processor/protobuf/protoc-gen-validate/requirements.txt
@@ -5,6 +5,6 @@ isort==5.7.0
 build==0.3.0
 twine==3.3.0
 wheel==0.38.1
-setuptools==70.0.0
+setuptools==65.5.1
 protobuf==3.20.2
 setuptools_scm[toml]>=6.2


### PR DESCRIPTION
Dependabot was trying to update dependencies inside the subtrees. Not something we want it to do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management configurations for `pip` and `gomod` ecosystems to enhance control over monthly updates.
	- Changed the `setuptools` package version from `70.0.0` to `65.5.1` for improved compatibility in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->