### PR TITLE
Dependabot updates GHA files sometimes

### DIFF
--- a/.dryrunsecurity.yaml
+++ b/.dryrunsecurity.yaml
@@ -1,10 +1,11 @@
 sensitiveCodepaths:
   # Files only allowed authors can modify
-  - '.github/**/*'
+  - ".github/**/*"
 allowedAuthors:
   usernames:
     # GitHub username
-    - 'sporkmonger'
+    - "sporkmonger"
+    - "dependabot"
 notificationList:
   # GitHub username or team name
-  - '@sporkmonger'
+  - "@sporkmonger"


### PR DESCRIPTION
This should prevent Dependabot changes to actions from failing the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added "dependabot" to the list of authorized authors, allowing for additional contributions.

- **Improvements**
	- Enhanced consistency in the configuration file formatting with updated quotation styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->