### PR TITLE
DryRun might see Dependabot's username differently

### DIFF
--- a/.dryrunsecurity.yaml
+++ b/.dryrunsecurity.yaml
@@ -6,6 +6,7 @@ allowedAuthors:
     # GitHub username
     - "sporkmonger"
     - "dependabot"
+    - "dependabot[bot]"
 notificationList:
   # GitHub username or team name
   - "@sporkmonger"


### PR DESCRIPTION
DryRun is still failing builds, possibly because it reads the Dependabot username differently?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the list of allowed authors to include "dependabot[bot]", enabling automated contributions from this entity to be recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->