### PR TITLE
Update license allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,13 +25,14 @@ skip = [
 [licenses]
 version = 2
 allow = [
-    "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "MIT",
     "MPL-2.0",
+    "Unicode-3.0",
 ]
 exceptions = [
     { allow = [


### PR DESCRIPTION
Unicode v3 license is acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Re-included "Apache-2.0" license in the allowed licenses list.
	- Added "Unicode-3.0" license to the allowed licenses list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->