### PR TITLE
Run tests only if rust changes were made.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,10 @@ name: Rust
 on:
   push:
     branches: [main]
+    paths: ['**/*.rs', '**/Cargo.*', '.github/**/*', 'crates/ext-processor/protobuf/**/*']
   pull_request:
     branches: [main]
+    paths: ['**/*.rs', '**/Cargo.*', '.github/**/*', 'crates/ext-processor/protobuf/**/*']
 
 jobs:
   fmt:


### PR DESCRIPTION
This might not work well with required status checks? It might also be better to split clippy and the linter out?